### PR TITLE
fix: correct DCA execution identity and harden admin flows

### DIFF
--- a/contracts/core/DCAVault.sol
+++ b/contracts/core/DCAVault.sol
@@ -38,8 +38,14 @@ contract DCAVault {
     // ========== STATE ==========
 
     address public owner;
+    address public pendingOwner;
+    uint256 public ownershipTransferUnlockAt;
     address public keeper;
+    address public pendingKeeper;
+    uint256 public keeperChangeUnlockAt;
     address public executor;     // PanoramaExecutor
+
+    uint256 public constant ADMIN_DELAY = 1 days;
 
     uint256 public nextOrderId;
     mapping(uint256 => Order) public orders;
@@ -66,6 +72,9 @@ contract DCAVault {
     event Deposited(uint256 indexed orderId, address indexed owner, uint256 amount);
     event Withdrawn(uint256 indexed orderId, address indexed owner, uint256 amount);
     event KeeperUpdated(address indexed oldKeeper, address indexed newKeeper);
+    event KeeperChangeScheduled(address indexed oldKeeper, address indexed newKeeper, uint256 executeAfter);
+    event OwnershipTransferStarted(address indexed currentOwner, address indexed pendingOwner, uint256 executeAfter);
+    event OwnershipTransferred(address indexed oldOwner, address indexed newOwner);
 
     // ========== ERRORS ==========
 
@@ -79,6 +88,7 @@ contract DCAVault {
     error ZeroAddress();
     error ZeroInterval();
     error Reentrancy();
+    error DelayNotElapsed();
 
     // ========== MODIFIERS ==========
 
@@ -243,20 +253,28 @@ contract DCAVault {
         // Build protocolId for aerodrome
         bytes32 protocolId = keccak256(abi.encodePacked("aerodrome"));
 
-        // Call PanoramaExecutor.executeSwap — tokenOut goes to order owner
-        (bool success,) = executor.call(
+        // Call PanoramaExecutor.executeSwapFor so funds come from this vault
+        // while the position and proceeds remain attributed to the order owner.
+        (bool success, bytes memory returndata) = executor.call(
             abi.encodeWithSignature(
-                "executeSwap(bytes32,address,address,uint256,uint256,bytes,uint256)",
+                "executeSwapFor(bytes32,address,address,address,address,uint256,uint256,address,bytes,uint256)",
                 protocolId,
+                order.owner,
+                address(this),
                 order.tokenIn,
                 order.tokenOut,
                 order.amountPerSwap,
                 amountOutMin,
+                order.owner,
                 extraData,
                 deadline
             )
         );
-        require(success, "DCAVault: swap failed");
+        if (!success) {
+            assembly {
+                revert(add(returndata, 0x20), mload(returndata))
+            }
+        }
 
         emit OrderExecuted(orderId, order.owner, order.amountPerSwap, block.timestamp);
     }
@@ -299,13 +317,35 @@ contract DCAVault {
 
     function setKeeper(address newKeeper) external onlyOwner {
         if (newKeeper == address(0)) revert ZeroAddress();
-        emit KeeperUpdated(keeper, newKeeper);
-        keeper = newKeeper;
+        pendingKeeper = newKeeper;
+        keeperChangeUnlockAt = block.timestamp + ADMIN_DELAY;
+        emit KeeperChangeScheduled(keeper, newKeeper, keeperChangeUnlockAt);
+    }
+
+    function executeKeeperChange() external onlyOwner {
+        if (pendingKeeper == address(0)) revert ZeroAddress();
+        if (block.timestamp < keeperChangeUnlockAt) revert DelayNotElapsed();
+        emit KeeperUpdated(keeper, pendingKeeper);
+        keeper = pendingKeeper;
+        pendingKeeper = address(0);
+        keeperChangeUnlockAt = 0;
     }
 
     function transferOwnership(address newOwner) external onlyOwner {
         if (newOwner == address(0)) revert ZeroAddress();
-        owner = newOwner;
+        pendingOwner = newOwner;
+        ownershipTransferUnlockAt = block.timestamp + ADMIN_DELAY;
+        emit OwnershipTransferStarted(owner, newOwner, ownershipTransferUnlockAt);
+    }
+
+    function acceptOwnership() external {
+        if (msg.sender != pendingOwner) revert Unauthorized();
+        if (block.timestamp < ownershipTransferUnlockAt) revert DelayNotElapsed();
+        address oldOwner = owner;
+        owner = pendingOwner;
+        pendingOwner = address(0);
+        ownershipTransferUnlockAt = 0;
+        emit OwnershipTransferred(oldOwner, owner);
     }
 
     // ========== INTERNAL ==========

--- a/contracts/core/PanoramaExecutor.sol
+++ b/contracts/core/PanoramaExecutor.sol
@@ -20,17 +20,43 @@ contract PanoramaExecutor {
     // ========== STATE ==========
 
     address public owner;
+    address public pendingOwner;
+    uint256 public ownershipTransferUnlockAt;
     /// @notice Implementation contracts for each protocol (used as clone templates)
     mapping(bytes32 => address) public adapterImplementations;
     /// @notice Per-user adapter clones: protocolId => user => clone address
     mapping(bytes32 => mapping(address => address)) public userAdapters;
+    /// @notice Trusted operators that may execute swaps on behalf of a user (e.g. DCA vaults).
+    mapping(address => bool) public authorizedOperators;
+    mapping(address => PendingOperatorChange) public pendingOperatorChanges;
+    mapping(bytes32 => PendingAdapterRemoval) public pendingAdapterRemovals;
     bool private _locked;
+
+    uint256 public constant ADMIN_DELAY = 1 days;
+
+    struct PendingOperatorChange {
+        bool authorized;
+        uint256 executeAfter;
+        bool exists;
+    }
+
+    struct PendingAdapterRemoval {
+        uint256 executeAfter;
+        bool exists;
+    }
 
     // ========== EVENTS ==========
 
     event AdapterRegistered(bytes32 indexed protocolId, address indexed implementation);
     event AdapterRemoved(bytes32 indexed protocolId, address indexed oldImplementation);
     event UserAdapterCreated(address indexed user, bytes32 indexed protocolId, address adapter);
+    event OwnershipTransferStarted(address indexed currentOwner, address indexed pendingOwner, uint256 executeAfter);
+    event OwnershipTransferred(address indexed oldOwner, address indexed newOwner);
+    event OperatorChangeScheduled(address indexed operator, bool authorized, uint256 executeAfter);
+    event OperatorChangeCancelled(address indexed operator);
+    event OperatorChangeExecuted(address indexed operator, bool authorized);
+    event AdapterRemovalScheduled(bytes32 indexed protocolId, uint256 executeAfter);
+    event AdapterRemovalCancelled(bytes32 indexed protocolId);
     event SwapExecuted(
         address indexed user,
         bytes32 indexed protocolId,
@@ -70,6 +96,10 @@ contract PanoramaExecutor {
     error TransferFailed();
     error Reentrancy();
     error ZeroAddress();
+    error InvalidToken();
+    error AlreadyRegistered();
+    error DelayNotElapsed();
+    error NoPendingChange();
 
     // ========== MODIFIERS ==========
 
@@ -90,6 +120,11 @@ contract PanoramaExecutor {
         _;
     }
 
+    modifier onlyAuthorizedOperator() {
+        if (!authorizedOperators[msg.sender]) revert Unauthorized();
+        _;
+    }
+
     // ========== CONSTRUCTOR ==========
 
     constructor() {
@@ -105,14 +140,18 @@ contract PanoramaExecutor {
      *      but has its own storage, so each user gets isolated gauge positions and rewards.
      */
     function _getOrCreateUserAdapter(bytes32 protocolId) internal returns (address adapter) {
-        adapter = userAdapters[protocolId][msg.sender];
+        return _getOrCreateUserAdapterFor(protocolId, msg.sender);
+    }
+
+    function _getOrCreateUserAdapterFor(bytes32 protocolId, address user) internal returns (address adapter) {
+        adapter = userAdapters[protocolId][user];
         if (adapter == address(0)) {
             address implementation = adapterImplementations[protocolId];
             if (implementation == address(0)) revert AdapterNotRegistered();
-            bytes32 salt = keccak256(abi.encodePacked(msg.sender, protocolId));
+            bytes32 salt = keccak256(abi.encodePacked(user, protocolId));
             adapter = Clones.cloneDeterministic(implementation, salt);
-            userAdapters[protocolId][msg.sender] = adapter;
-            emit UserAdapterCreated(msg.sender, protocolId, adapter);
+            userAdapters[protocolId][user] = adapter;
+            emit UserAdapterCreated(user, protocolId, adapter);
         }
     }
 
@@ -164,6 +203,35 @@ contract PanoramaExecutor {
         emit SwapExecuted(msg.sender, protocolId, tokenIn, tokenOut, amountIn, amountOut);
     }
 
+    /**
+     * @notice Execute a swap funded by a trusted operator while preserving the end user's adapter isolation.
+     * @dev Used by automation contracts such as DCAVault. Tokens are pulled from `tokenPayer`,
+     *      positions remain attributed to `adapterOwner`, and swap proceeds are sent to `recipient`.
+     */
+    function executeSwapFor(
+        bytes32 protocolId,
+        address adapterOwner,
+        address tokenPayer,
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address recipient,
+        bytes calldata extraData,
+        uint256 deadline
+    ) external payable nonReentrant beforeDeadline(deadline) onlyAuthorizedOperator returns (uint256 amountOut) {
+        if (adapterOwner == address(0) || tokenPayer == address(0) || recipient == address(0)) revert ZeroAddress();
+        if (tokenIn == address(0)) revert InvalidToken();
+        if (amountIn == 0) revert InvalidAmount();
+
+        address adapter = _getOrCreateUserAdapterFor(protocolId, adapterOwner);
+        tokenIn.safeTransferFrom(tokenPayer, adapter, amountIn);
+        amountOut = IProtocolAdapter(adapter).swap(tokenIn, tokenOut, amountIn, amountOutMin, recipient, extraData);
+
+        if (amountOut < amountOutMin) revert InsufficientOutput();
+        emit SwapExecuted(adapterOwner, protocolId, tokenIn, tokenOut, amountIn, amountOut);
+    }
+
     // ========== LIQUIDITY ==========
 
     function executeAddLiquidity(
@@ -179,6 +247,7 @@ contract PanoramaExecutor {
         uint256 deadline
     ) external payable nonReentrant beforeDeadline(deadline) returns (uint256 liquidity) {
         if (amountADesired == 0 || amountBDesired == 0) revert InvalidAmount();
+        if (tokenA == address(0) || tokenB == address(0)) revert InvalidToken();
         address adapter = _getOrCreateUserAdapter(protocolId);
 
         tokenA.safeTransferFrom(msg.sender, adapter, amountADesired);
@@ -203,6 +272,7 @@ contract PanoramaExecutor {
         uint256 deadline
     ) external nonReentrant beforeDeadline(deadline) returns (uint256 amountA, uint256 amountB) {
         if (liquidity == 0) revert InvalidAmount();
+        if (tokenA == address(0) || tokenB == address(0)) revert InvalidToken();
         address adapter = _getOrCreateUserAdapter(protocolId);
 
         address pool = abi.decode(extraData, (address));
@@ -266,19 +336,74 @@ contract PanoramaExecutor {
      */
     function registerAdapter(bytes32 protocolId, address implementation) external onlyOwner {
         if (implementation == address(0)) revert ZeroAddress();
+        if (adapterImplementations[protocolId] != address(0)) revert AlreadyRegistered();
         adapterImplementations[protocolId] = implementation;
         emit AdapterRegistered(protocolId, implementation);
     }
 
+    function setAuthorizedOperator(address operator, bool authorized) external onlyOwner {
+        if (operator == address(0)) revert ZeroAddress();
+        pendingOperatorChanges[operator] = PendingOperatorChange({
+            authorized: authorized,
+            executeAfter: block.timestamp + ADMIN_DELAY,
+            exists: true
+        });
+        emit OperatorChangeScheduled(operator, authorized, block.timestamp + ADMIN_DELAY);
+    }
+
+    function executeAuthorizedOperatorChange(address operator) external onlyOwner {
+        PendingOperatorChange memory change = pendingOperatorChanges[operator];
+        if (!change.exists) revert NoPendingChange();
+        if (block.timestamp < change.executeAfter) revert DelayNotElapsed();
+        authorizedOperators[operator] = change.authorized;
+        delete pendingOperatorChanges[operator];
+        emit OperatorChangeExecuted(operator, change.authorized);
+    }
+
+    function cancelAuthorizedOperatorChange(address operator) external onlyOwner {
+        if (!pendingOperatorChanges[operator].exists) revert NoPendingChange();
+        delete pendingOperatorChanges[operator];
+        emit OperatorChangeCancelled(operator);
+    }
+
     function removeAdapter(bytes32 protocolId) external onlyOwner {
+        if (adapterImplementations[protocolId] == address(0)) revert AdapterNotRegistered();
+        pendingAdapterRemovals[protocolId] =
+            PendingAdapterRemoval({executeAfter: block.timestamp + ADMIN_DELAY, exists: true});
+        emit AdapterRemovalScheduled(protocolId, block.timestamp + ADMIN_DELAY);
+    }
+
+    function executeAdapterRemoval(bytes32 protocolId) external onlyOwner {
+        PendingAdapterRemoval memory pending = pendingAdapterRemovals[protocolId];
+        if (!pending.exists) revert NoPendingChange();
+        if (block.timestamp < pending.executeAfter) revert DelayNotElapsed();
         address old = adapterImplementations[protocolId];
         delete adapterImplementations[protocolId];
+        delete pendingAdapterRemovals[protocolId];
         emit AdapterRemoved(protocolId, old);
+    }
+
+    function cancelAdapterRemoval(bytes32 protocolId) external onlyOwner {
+        if (!pendingAdapterRemovals[protocolId].exists) revert NoPendingChange();
+        delete pendingAdapterRemovals[protocolId];
+        emit AdapterRemovalCancelled(protocolId);
     }
 
     function transferOwnership(address newOwner) external onlyOwner {
         if (newOwner == address(0)) revert ZeroAddress();
-        owner = newOwner;
+        pendingOwner = newOwner;
+        ownershipTransferUnlockAt = block.timestamp + ADMIN_DELAY;
+        emit OwnershipTransferStarted(owner, newOwner, ownershipTransferUnlockAt);
+    }
+
+    function acceptOwnership() external {
+        if (msg.sender != pendingOwner) revert Unauthorized();
+        if (block.timestamp < ownershipTransferUnlockAt) revert DelayNotElapsed();
+        address oldOwner = owner;
+        owner = pendingOwner;
+        pendingOwner = address(0);
+        ownershipTransferUnlockAt = 0;
+        emit OwnershipTransferred(oldOwner, owner);
     }
 
     function emergencyWithdraw() external onlyOwner {

--- a/script/DeployDCAVault.s.sol
+++ b/script/DeployDCAVault.s.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.20;
 
 import "forge-std/Script.sol";
 import {DCAVault} from "../contracts/core/DCAVault.sol";
+import {PanoramaExecutor} from "../contracts/core/PanoramaExecutor.sol";
 
 /**
  * @title DeployDCAVault
@@ -23,6 +24,7 @@ contract DeployDCAVault is Script {
 
         // Keeper = deployer wallet (change to dedicated keeper address if needed)
         DCAVault vault = new DCAVault(deployer, EXECUTOR);
+        PanoramaExecutor(payable(EXECUTOR)).setAuthorizedOperator(address(vault), true);
 
         vm.stopBroadcast();
 
@@ -31,7 +33,11 @@ contract DeployDCAVault is Script {
         console.log("Vault:   ", address(vault));
         console.log("Keeper:  ", deployer);
         console.log("Executor:", EXECUTOR);
-        console.log("\nNext step: add to backend/.env:");
+        console.log("\nNext step after 24h delay:");
+        console.log(
+            "call executeAuthorizedOperatorChange(vault) on PanoramaExecutor to activate DCA automation"
+        );
+        console.log("\nThen add to backend/.env:");
         console.log("DCA_VAULT_ADDRESS=", address(vault));
     }
 }

--- a/test/DCAVault.t.sol
+++ b/test/DCAVault.t.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import {PanoramaExecutor} from "../contracts/core/PanoramaExecutor.sol";
+import {AerodromeAdapter} from "../contracts/adapters/AerodromeAdapter.sol";
+import {DCAVault} from "../contracts/core/DCAVault.sol";
+import {MockERC20} from "./mocks/MockERC20.sol";
+import {MockRouter} from "./mocks/MockRouter.sol";
+
+contract DCAVaultTest is Test {
+    PanoramaExecutor public executor;
+    AerodromeAdapter public adapter;
+    DCAVault public vault;
+    MockRouter public mockRouter;
+    MockERC20 public tokenIn;
+    MockERC20 public tokenOut;
+    MockERC20 public weth;
+
+    address public owner = address(this);
+    address public keeper = address(0xCAFE);
+    address public user = address(0xBEEF);
+
+    bytes32 public constant AERODROME_ID = keccak256("aerodrome");
+
+    function setUp() public {
+        tokenIn = new MockERC20("Token In", "TIN", 18);
+        tokenOut = new MockERC20("Token Out", "TOUT", 6);
+        weth = new MockERC20("Wrapped ETH", "WETH", 18);
+        mockRouter = new MockRouter(address(weth), address(0xFACE));
+
+        executor = new PanoramaExecutor();
+        adapter = new AerodromeAdapter(address(mockRouter), address(0xDEAD), address(executor));
+        executor.registerAdapter(AERODROME_ID, address(adapter));
+
+        vault = new DCAVault(keeper, address(executor));
+        executor.setAuthorizedOperator(address(vault), true);
+        vm.warp(block.timestamp + executor.ADMIN_DELAY());
+        executor.executeAuthorizedOperatorChange(address(vault));
+
+        tokenIn.mint(user, 1000e18);
+    }
+
+    function test_Execute_UsesUserAdapterAndPaysUser() public {
+        uint256 depositAmount = 100e18;
+        uint256 swapAmount = 25e18;
+
+        vm.startPrank(user);
+        tokenIn.approve(address(vault), depositAmount);
+        uint256 orderId = vault.createOrder(address(tokenIn), address(tokenOut), swapAmount, 1 hours, 4, false, depositAmount);
+        vm.stopPrank();
+
+        assertEq(orderId, 0);
+        assertEq(tokenOut.balanceOf(user), 0);
+        assertEq(executor.getUserAdapter(AERODROME_ID, user), address(0));
+        assertEq(executor.getUserAdapter(AERODROME_ID, address(vault)), address(0));
+
+        vm.warp(block.timestamp + 1 hours);
+        vm.prank(keeper);
+        vault.execute(orderId, 0, abi.encode(false), block.timestamp + 1 hours);
+
+        address userAdapter = executor.getUserAdapter(AERODROME_ID, user);
+        assertTrue(userAdapter != address(0), "user adapter should be created");
+        assertEq(executor.getUserAdapter(AERODROME_ID, address(vault)), address(0), "vault must not get its own adapter");
+        assertEq(tokenOut.balanceOf(user), swapAmount, "swap output should go to the order owner");
+
+        (, , , , , uint256 lastExecuted, uint256 remainingSwaps, uint256 balance, , bool active) = vault.orders(orderId);
+        assertGt(lastExecuted, 0, "order should be marked executed");
+        assertEq(remainingSwaps, 3, "remaining swaps should decrease");
+        assertEq(balance, depositAmount - swapAmount, "vault balance should decrease by one swap");
+        assertTrue(active, "order should remain active");
+    }
+}

--- a/test/PanoramaExecutor.t.sol
+++ b/test/PanoramaExecutor.t.sol
@@ -64,11 +64,21 @@ contract PanoramaExecutorTest is Test {
 
     function test_RemoveAdapter() public {
         executor.removeAdapter(AERODROME_ID);
+        vm.warp(block.timestamp + executor.ADMIN_DELAY());
+        executor.executeAdapterRemoval(AERODROME_ID);
         assertEq(executor.adapterImplementations(AERODROME_ID), address(0));
+    }
+
+    function test_RemoveAdapter_SchedulesFirst() public {
+        executor.removeAdapter(AERODROME_ID);
+        assertEq(executor.adapterImplementations(AERODROME_ID), address(adapter));
     }
 
     function test_TransferOwnership() public {
         executor.transferOwnership(user);
+        vm.warp(block.timestamp + executor.ADMIN_DELAY());
+        vm.prank(user);
+        executor.acceptOwnership();
         assertEq(executor.owner(), user);
     }
 
@@ -111,6 +121,40 @@ contract PanoramaExecutorTest is Test {
         vm.prank(user);
         vm.expectRevert(PanoramaExecutor.AdapterNotRegistered.selector);
         executor.executeSwap(keccak256("unknown"), address(tokenA), address(tokenB), 1e18, 0, "", block.timestamp + 1);
+    }
+
+    function test_ExecuteSwapFor_OnlyAuthorizedOperator() public {
+        vm.startPrank(user);
+        tokenA.approve(address(executor), 1e18);
+        vm.expectRevert(PanoramaExecutor.Unauthorized.selector);
+        executor.executeSwapFor(
+            AERODROME_ID, user, user, address(tokenA), address(tokenB), 1e18, 0, user, abi.encode(false), block.timestamp + 1
+        );
+        vm.stopPrank();
+    }
+
+    function test_ExecuteSwapFor_AuthorizedOperator_AfterDelay() public {
+        executor.setAuthorizedOperator(address(this), true);
+        vm.warp(block.timestamp + executor.ADMIN_DELAY());
+        executor.executeAuthorizedOperatorChange(address(this));
+
+        tokenA.mint(address(this), 5e18);
+        tokenA.approve(address(executor), 1e18);
+
+        uint256 amountOut = executor.executeSwapFor(
+            AERODROME_ID, user, address(this), address(tokenA), address(tokenB), 1e18, 0, user, abi.encode(false), block.timestamp + 1
+        );
+
+        assertEq(amountOut, 1e18);
+        assertEq(tokenB.balanceOf(user), 1000e18 + 1e18);
+    }
+
+    function test_ExecuteAddLiquidity_InvalidToken() public {
+        vm.prank(user);
+        vm.expectRevert(PanoramaExecutor.InvalidToken.selector);
+        executor.executeAddLiquidity(
+            AERODROME_ID, address(0), address(tokenB), false, 1e18, 1e18, 0, 0, "0x", block.timestamp + 1
+        );
     }
 
     // ========== EMERGENCY TESTS ==========


### PR DESCRIPTION
Summary
- Fix DCA execution to use the end user's adapter/recipient correctly
- Add delayed/two-step admin controls for executor and vault
- Bubble DCA swap revert data
- Add contract test coverage

Verification
- forge test --no-match-path 'test/fork/*'
