### PR TITLE
fix: tighten quote math, slippage handling, and APR semantics

### DIFF
--- a/backend/src/controllers/execution.controller.ts
+++ b/backend/src/controllers/execution.controller.ts
@@ -6,6 +6,15 @@ import { executePrepareStake, executePrepareUnstake } from "../usecases/prepare-
 import { executeGetPools, executeGetPoolDetail } from "../usecases/get-pools.usecase";
 import { executeCheckAllowance } from "../usecases/check-allowance.usecase";
 import { executePrepareApprove } from "../usecases/prepare-approve.usecase";
+import { AppError } from "../shared/errorCodes";
+
+function handleControllerError(err: unknown, res: Response) {
+  if (err instanceof AppError) {
+    return res.status(err.status).json({ error: err.details ?? err.message });
+  }
+  const message = err instanceof Error ? err.message : "Internal server error";
+  return res.status(500).json({ error: message });
+}
 
 export async function getQuote(req: Request, res: Response) {
   try {
@@ -16,7 +25,7 @@ export async function getQuote(req: Request, res: Response) {
     const result = await executeGetQuote({ tokenIn, tokenOut, amountIn, stable });
     return res.json(result);
   } catch (err: any) {
-    return res.status(500).json({ error: err.message });
+    return handleControllerError(err, res);
   }
 }
 
@@ -29,7 +38,7 @@ export async function prepareSwap(req: Request, res: Response) {
     const tx = await executePrepareSwap({ tokenIn, tokenOut, amountIn, slippageBps, userAddress, stable, deadlineMinutes });
     return res.json(tx);
   } catch (err: any) {
-    return res.status(500).json({ error: err.message });
+    return handleControllerError(err, res);
   }
 }
 
@@ -42,7 +51,7 @@ export async function prepareLiquidity(req: Request, res: Response) {
     const tx = await executePrepareAddLiquidity({ tokenA, tokenB, amountA, amountB, slippageBps, stable, deadlineMinutes });
     return res.json(tx);
   } catch (err: any) {
-    return res.status(500).json({ error: err.message });
+    return handleControllerError(err, res);
   }
 }
 
@@ -55,7 +64,7 @@ export async function prepareStake(req: Request, res: Response) {
     const tx = await executePrepareStake({ lpToken, amount });
     return res.json(tx);
   } catch (err: any) {
-    return res.status(500).json({ error: err.message });
+    return handleControllerError(err, res);
   }
 }
 
@@ -68,7 +77,7 @@ export async function prepareUnstake(req: Request, res: Response) {
     const tx = await executePrepareUnstake({ lpToken, amount });
     return res.json(tx);
   } catch (err: any) {
-    return res.status(500).json({ error: err.message });
+    return handleControllerError(err, res);
   }
 }
 
@@ -77,7 +86,7 @@ export async function getPools(_req: Request, res: Response) {
     const result = await executeGetPools();
     return res.json(result);
   } catch (err: any) {
-    return res.status(500).json({ error: err.message });
+    return handleControllerError(err, res);
   }
 }
 
@@ -90,7 +99,7 @@ export async function checkAllowance(req: Request, res: Response) {
     const result = await executeCheckAllowance({ token, owner, spender });
     return res.json(result);
   } catch (err: any) {
-    return res.status(500).json({ error: err.message });
+    return handleControllerError(err, res);
   }
 }
 
@@ -103,7 +112,7 @@ export async function prepareApprove(req: Request, res: Response) {
     const tx = await executePrepareApprove({ token, spender, amount });
     return res.json(tx);
   } catch (err: any) {
-    return res.status(500).json({ error: err.message });
+    return handleControllerError(err, res);
   }
 }
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -15,16 +15,31 @@ dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 3010;
+const allowedOrigins = (process.env.CORS_ORIGINS ?? "http://localhost:3000,http://127.0.0.1:3000")
+  .split(",")
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+const swaggerEnabled = process.env.ENABLE_SWAGGER === "true" || process.env.NODE_ENV !== "production";
 
 app.use(helmet());
-app.use(cors());
-app.use(express.json());
+app.use(cors({
+  origin(origin, callback) {
+    if (!origin || allowedOrigins.includes(origin)) {
+      callback(null, true);
+      return;
+    }
+    callback(new Error("Origin not allowed by CORS"));
+  },
+}));
+app.use(express.json({ limit: "1mb" }));
 app.use(rateLimiter);
 
-app.use("/docs", swaggerUi.serve, swaggerUi.setup(swaggerDoc, {
-  customCss: '.swagger-ui .topbar { display: none }',
-  customSiteTitle: "PanoramaBlock API Docs",
-}));
+if (swaggerEnabled) {
+  app.use("/docs", swaggerUi.serve, swaggerUi.setup(swaggerDoc, {
+    customCss: '.swagger-ui .topbar { display: none }',
+    customSiteTitle: "PanoramaBlock API Docs",
+  }));
+}
 
 app.use("/execution", executionRoutes);
 app.use("/staking", stakingRoutes);

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,0 +1,93 @@
+import { Request, Response, NextFunction } from "express";
+import { ethers } from "ethers";
+import { AppError } from "../shared/errorCodes";
+import { TxModule } from "../shared/transactionStore";
+
+const AUTH_WINDOW_MS = 5 * 60 * 1000;
+
+function parseTimestamp(value: unknown): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new AppError("MISSING_FIELD", "Missing or invalid timestamp");
+  }
+  return parsed;
+}
+
+function validateFreshTimestamp(timestamp: number) {
+  if (Math.abs(Date.now() - timestamp) > AUTH_WINDOW_MS) {
+    throw new AppError("AUTH_EXPIRED");
+  }
+}
+
+function recoverSigner(message: string, signature: unknown): string {
+  if (typeof signature !== "string" || signature.length === 0) {
+    throw new AppError("MISSING_FIELD", "Missing required field: signature");
+  }
+  try {
+    return ethers.verifyMessage(message, signature);
+  } catch {
+    throw new AppError("INVALID_SIGNATURE");
+  }
+}
+
+function assertUserSignature(expectedUser: string, signer: string) {
+  if (signer.toLowerCase() !== expectedUser.toLowerCase()) {
+    throw new AppError("INVALID_SIGNATURE");
+  }
+}
+
+function buildTxSubmitMessage(module: TxModule, userAddress: string, txHash: string, action: string, timestamp: number): string {
+  return [
+    "PanoramaBlock transaction submission",
+    `module:${module}`,
+    `user:${userAddress.toLowerCase()}`,
+    `txHash:${txHash.toLowerCase()}`,
+    `action:${action}`,
+    `timestamp:${timestamp}`,
+  ].join("\n");
+}
+
+function buildHistoryMessage(module: TxModule, userAddress: string, timestamp: number): string {
+  return [
+    "PanoramaBlock history access",
+    `module:${module}`,
+    `user:${userAddress.toLowerCase()}`,
+    `timestamp:${timestamp}`,
+  ].join("\n");
+}
+
+export function requireSignedTxSubmission(module: TxModule) {
+  return (req: Request, _res: Response, next: NextFunction) => {
+    try {
+      const { userAddress, txHash, action, timestamp, signature } = req.body;
+      if (typeof userAddress !== "string" || typeof txHash !== "string") {
+        throw new AppError("MISSING_FIELD", "Missing required fields: userAddress, txHash");
+      }
+
+      const ts = parseTimestamp(timestamp);
+      validateFreshTimestamp(ts);
+      const message = buildTxSubmitMessage(module, userAddress, txHash, String(action ?? module), ts);
+      const signer = recoverSigner(message, signature);
+      assertUserSignature(userAddress, signer);
+      next();
+    } catch (err) {
+      next(err);
+    }
+  };
+}
+
+export function requireSignedHistoryAccess(module: TxModule) {
+  return (req: Request, _res: Response, next: NextFunction) => {
+    try {
+      const userAddress = String(req.params.userAddress ?? "");
+      const timestamp = parseTimestamp(req.query.timestamp);
+      validateFreshTimestamp(timestamp);
+      const message = buildHistoryMessage(module, userAddress, timestamp);
+      const signer = recoverSigner(message, req.query.signature);
+      assertUserSignature(userAddress, signer);
+      next();
+    } catch (err) {
+      next(err);
+    }
+  };
+}

--- a/backend/src/modules/dca/routes/dca.routes.ts
+++ b/backend/src/modules/dca/routes/dca.routes.ts
@@ -11,6 +11,7 @@ import {
 } from "../controllers/dca.controller";
 import { asyncHandler } from "../../../middleware/errorHandler";
 import { validateAddress, validateRequired, validateTxHash } from "../../../middleware/validation";
+import { requireSignedHistoryAccess, requireSignedTxSubmission } from "../../../middleware/auth";
 
 export const dcaRoutes = Router();
 
@@ -43,6 +44,7 @@ dcaRoutes.post("/transaction/submit",
   validateRequired("txHash", "userAddress"),
   validateTxHash("txHash"),
   validateAddress("userAddress"),
+  requireSignedTxSubmission("dca"),
   asyncHandler(submitDcaTx)
 );
 
@@ -53,5 +55,6 @@ dcaRoutes.get("/transaction/:txHash",
 
 dcaRoutes.get("/history/:userAddress",
   validateAddress("userAddress", "params"),
+  requireSignedHistoryAccess("dca"),
   asyncHandler(getDcaHistory)
 );

--- a/backend/src/modules/liquid-staking/controllers/staking.controller.ts
+++ b/backend/src/modules/liquid-staking/controllers/staking.controller.ts
@@ -17,9 +17,9 @@ export async function prepareEnterStrategy(req: Request, res: Response) {
 }
 
 export async function prepareExitStrategy(req: Request, res: Response) {
-  const { userAddress, poolId, amount, deadlineMinutes } = req.body;
+  const { userAddress, poolId, amount, slippageBps, deadlineMinutes } = req.body;
   const result = await executeExitStrategy({
-    userAddress, poolId, amount, deadlineMinutes,
+    userAddress, poolId, amount, slippageBps, deadlineMinutes,
   });
   return res.json(result);
 }

--- a/backend/src/modules/liquid-staking/routes/staking.routes.ts
+++ b/backend/src/modules/liquid-staking/routes/staking.routes.ts
@@ -48,6 +48,7 @@ stakingRoutes.post("/prepare-enter",
 stakingRoutes.post("/prepare-exit",
   validateRequired("userAddress", "poolId"),
   validateAddress("userAddress"),
+  validateSlippage(),
   asyncHandler(prepareExitStrategy)
 );
 

--- a/backend/src/modules/liquid-staking/routes/staking.routes.ts
+++ b/backend/src/modules/liquid-staking/routes/staking.routes.ts
@@ -13,6 +13,7 @@ import {
 } from "../controllers/staking.controller";
 import { asyncHandler } from "../../../middleware/errorHandler";
 import { validateAddress, validateAmount, validateRequired, validateSlippage, validateTxHash } from "../../../middleware/validation";
+import { requireSignedHistoryAccess, requireSignedTxSubmission } from "../../../middleware/auth";
 
 export const stakingRoutes = Router();
 
@@ -61,6 +62,7 @@ stakingRoutes.post("/transaction/submit",
   validateRequired("txHash", "userAddress"),
   validateTxHash("txHash"),
   validateAddress("userAddress"),
+  requireSignedTxSubmission("staking"),
   asyncHandler(submitTx)
 );
 
@@ -71,5 +73,6 @@ stakingRoutes.get("/transaction/:txHash",
 
 stakingRoutes.get("/history/:userAddress",
   validateAddress("userAddress", "params"),
+  requireSignedHistoryAccess("staking"),
   asyncHandler(getTxHistory)
 );

--- a/backend/src/modules/liquid-staking/usecases/get-protocol-info.usecase.ts
+++ b/backend/src/modules/liquid-staking/usecases/get-protocol-info.usecase.ts
@@ -1,9 +1,9 @@
 import { ethers } from "ethers";
 import { getEnabledStakingPools } from "../config/staking-pools";
 import { getPoolAddress } from "../../../providers/aerodrome.provider";
-import { getGaugeForPool, getRewardRate } from "../../../providers/gauge.provider";
+import { getGaugeForPool } from "../../../providers/gauge.provider";
 import { getContract } from "../../../providers/chain.provider";
-import { GAUGE_ABI, POOL_ABI } from "../../../utils/abi";
+import { GAUGE_ABI } from "../../../utils/abi";
 
 async function withRetry<T>(fn: () => Promise<T>, retries = 2, delayMs = 500): Promise<T> {
   for (let i = 0; i <= retries; i++) {
@@ -15,7 +15,7 @@ async function withRetry<T>(fn: () => Promise<T>, retries = 2, delayMs = 500): P
   throw new Error("withRetry exhausted");
 }
 
-/** Fetch fee-based APR from DexScreener as fallback */
+/** Fetch fee-based APR from DexScreener. This is fee APR only, not total strategy APR. */
 async function fetchDexScreenerAPR(poolAddress: string, feeRate: number): Promise<string | null> {
   try {
     const res = await fetch(`https://api.dexscreener.com/latest/dex/pairs/base/${poolAddress}`, {
@@ -43,6 +43,8 @@ interface PoolInfo {
   rewardRatePerSecond: string;
   totalStaked: string;
   estimatedAPR: string;
+  aprSource: "dexscreener_fee_apr" | "unavailable";
+  aprDisclaimer: string;
 }
 
 export interface GetProtocolInfoResponse {
@@ -98,28 +100,9 @@ export async function executeGetProtocolInfo(): Promise<GetProtocolInfoResponse>
         console.error(`[PROTOCOL-INFO]   totalSupply FAILED:`, e instanceof Error ? e.message : e);
       }
 
-      // Estimate APR: try on-chain gauge first, then DexScreener fee APR as fallback
-      let estimatedAPR = "0";
-      if (totalStaked > 0n && rewardRate > 0n) {
-        // On-chain: compare AERO rewards value vs LP staked value
-        // Simplified: just use fee-based APR from DexScreener for accuracy
-        const secondsPerYear = 365n * 24n * 3600n;
-        const yearlyRewards = rewardRate * secondsPerYear;
-        const aprBps = (yearlyRewards * 10000n) / totalStaked;
-        estimatedAPR = (Number(aprBps) / 100).toFixed(2);
-      }
-
-      // If on-chain APR is 0 or absurdly high (>10000%), use DexScreener fee APR
-      const aprNum = parseFloat(estimatedAPR);
-      if (aprNum === 0 || aprNum > 10000) {
-        const feeRate = pool.stable ? 0.0001 : 0.003; // 1bp stable, 30bp volatile
-        const dexAPR = await fetchDexScreenerAPR(poolAddress, feeRate);
-        if (dexAPR) {
-          console.log(`[PROTOCOL-INFO]   Using DexScreener APR: ${dexAPR} (on-chain was ${estimatedAPR}%)`);
-          estimatedAPR = dexAPR.replace("%", "");
-        }
-      }
-      console.log(`[PROTOCOL-INFO]   estimatedAPR=${estimatedAPR}%`);
+      const feeRate = pool.stable ? 0.0001 : 0.003; // 1bp stable, 30bp volatile
+      const estimatedAPR = await fetchDexScreenerAPR(poolAddress, feeRate);
+      console.log(`[PROTOCOL-INFO]   estimatedFeeAPR=${estimatedAPR ?? "unavailable"}`);
 
       pools.push({
         poolId: pool.id,
@@ -129,7 +112,9 @@ export async function executeGetProtocolInfo(): Promise<GetProtocolInfoResponse>
         stable: pool.stable,
         rewardRatePerSecond: rewardRate.toString(),
         totalStaked: totalStaked.toString(),
-        estimatedAPR: `${estimatedAPR}%`,
+        estimatedAPR: estimatedAPR ?? "unavailable",
+        aprSource: estimatedAPR ? "dexscreener_fee_apr" : "unavailable",
+        aprDisclaimer: "Fee APR estimate only. Does not include reward-token incentives or impermanent loss.",
       });
     } catch (err) {
       console.error(`[PROTOCOL-INFO] Pool ${pool.name} FAILED entirely:`, err instanceof Error ? err.message : err);

--- a/backend/src/modules/liquid-staking/usecases/prepare-enter-strategy.usecase.ts
+++ b/backend/src/modules/liquid-staking/usecases/prepare-enter-strategy.usecase.ts
@@ -8,6 +8,7 @@ import { getContract } from "../../../providers/chain.provider";
 import { PANORAMA_EXECUTOR_ABI, AERODROME_ROUTER_ABI, ERC20_ABI } from "../../../utils/abi";
 import { encodeProtocolId, getDeadline, isNativeETH, applySlippage } from "../../../utils/encoding";
 import { PreparedTransaction, TransactionBundle } from "../../../types/transaction";
+import { AppError } from "../../../shared/errorCodes";
 
 export interface PrepareEnterStrategyRequest {
   userAddress: string;
@@ -60,6 +61,12 @@ export async function executeEnterStrategy(
   const executorAddress = chain.contracts.panoramaExecutor;
   if (!executorAddress) {
     throw new Error("Executor contract not configured");
+  }
+  if (isNativeETH(poolConfig.tokenA.address) || isNativeETH(poolConfig.tokenB.address)) {
+    throw new AppError(
+      "UNSUPPORTED_OPERATION",
+      "Native ETH liquidity is not supported by PanoramaExecutor; use ERC-20 wrapped assets"
+    );
   }
   let amountADesired = BigInt(req.amountA);
   let amountBDesired = BigInt(req.amountB);
@@ -139,50 +146,41 @@ export async function executeEnterStrategy(
   const erc20Iface = new ethers.Interface(ERC20_ABI);
   const executorIface = new ethers.Interface(PANORAMA_EXECUTOR_ABI);
 
-  // Step 1 - Approve tokenA to Executor (if not native ETH)
-  // Use MaxUint256 so approval only happens once per token
-  if (!isNativeETH(poolConfig.tokenA.address)) {
-    const allowanceA: bigint = await withRetry(async () => {
-      const c = getContract(poolConfig.tokenA.address, ERC20_ABI, "base");
-      return c.allowance(req.userAddress, executorAddress) as Promise<bigint>;
-    }, 4, 800).catch((e) => { console.error(`[ENTER] allowance check ${poolConfig.tokenA.symbol} FAILED:`, e instanceof Error ? e.message : e); return 0n; });
-    console.log(`[ENTER] ${poolConfig.tokenA.symbol} allowance=${allowanceA.toString()}, needed=${amountADesired.toString()}, skip=${allowanceA >= amountADesired}`);
-    if (allowanceA < amountADesired) {
-      steps.push({
-        to: poolConfig.tokenA.address,
-        data: erc20Iface.encodeFunctionData("approve", [executorAddress, ethers.MaxUint256]),
-        value: "0",
-        chainId: chain.chainId,
-        description: `Approve ${poolConfig.tokenA.symbol}`,
-      });
-    }
+  // Step 1 - Approve tokenA to Executor for the exact amount required
+  const allowanceA: bigint = await withRetry(async () => {
+    const c = getContract(poolConfig.tokenA.address, ERC20_ABI, "base");
+    return c.allowance(req.userAddress, executorAddress) as Promise<bigint>;
+  }, 4, 800).catch((e) => { console.error(`[ENTER] allowance check ${poolConfig.tokenA.symbol} FAILED:`, e instanceof Error ? e.message : e); return 0n; });
+  console.log(`[ENTER] ${poolConfig.tokenA.symbol} allowance=${allowanceA.toString()}, needed=${amountADesired.toString()}, skip=${allowanceA >= amountADesired}`);
+  if (allowanceA < amountADesired) {
+    steps.push({
+      to: poolConfig.tokenA.address,
+      data: erc20Iface.encodeFunctionData("approve", [executorAddress, amountADesired]),
+      value: "0",
+      chainId: chain.chainId,
+      description: `Approve ${poolConfig.tokenA.symbol}`,
+    });
   }
 
-  // Step 2 - Approve tokenB to Executor (if not native ETH)
-  if (!isNativeETH(poolConfig.tokenB.address)) {
-    const allowanceB: bigint = await withRetry(async () => {
-      const c = getContract(poolConfig.tokenB.address, ERC20_ABI, "base");
-      return c.allowance(req.userAddress, executorAddress) as Promise<bigint>;
-    }, 4, 800).catch((e) => { console.error(`[ENTER] allowance check ${poolConfig.tokenB.symbol} FAILED:`, e instanceof Error ? e.message : e); return 0n; });
-    console.log(`[ENTER] ${poolConfig.tokenB.symbol} allowance=${allowanceB.toString()}, needed=${amountBDesired.toString()}, skip=${allowanceB >= amountBDesired}`);
-    if (allowanceB < amountBDesired) {
-      steps.push({
-        to: poolConfig.tokenB.address,
-        data: erc20Iface.encodeFunctionData("approve", [executorAddress, ethers.MaxUint256]),
-        value: "0",
-        chainId: chain.chainId,
-        description: `Approve ${poolConfig.tokenB.symbol}`,
-      });
-    }
+  // Step 2 - Approve tokenB to Executor for the exact amount required
+  const allowanceB: bigint = await withRetry(async () => {
+    const c = getContract(poolConfig.tokenB.address, ERC20_ABI, "base");
+    return c.allowance(req.userAddress, executorAddress) as Promise<bigint>;
+  }, 4, 800).catch((e) => { console.error(`[ENTER] allowance check ${poolConfig.tokenB.symbol} FAILED:`, e instanceof Error ? e.message : e); return 0n; });
+  console.log(`[ENTER] ${poolConfig.tokenB.symbol} allowance=${allowanceB.toString()}, needed=${amountBDesired.toString()}, skip=${allowanceB >= amountBDesired}`);
+  if (allowanceB < amountBDesired) {
+    steps.push({
+      to: poolConfig.tokenB.address,
+      data: erc20Iface.encodeFunctionData("approve", [executorAddress, amountBDesired]),
+      value: "0",
+      chainId: chain.chainId,
+      description: `Approve ${poolConfig.tokenB.symbol}`,
+    });
   }
 
   // Step 3 - Add Liquidity via PanoramaExecutor
   const protocolId = encodeProtocolId("aerodrome");
   const deadline = getDeadline(deadlineMinutes);
-
-  let value = "0";
-  if (isNativeETH(poolConfig.tokenA.address)) value = amountADesired.toString();
-  else if (isNativeETH(poolConfig.tokenB.address)) value = amountBDesired.toString();
 
   steps.push({
     to: executorAddress,
@@ -198,10 +196,13 @@ export async function executeEnterStrategy(
       "0x",
       deadline,
     ]),
-    value,
+    value: "0",
     chainId: chain.chainId,
     description: `Add liquidity to ${poolConfig.name}`,
   });
+
+  // Use slippage-adjusted LP amount to account for differences between quote and execution.
+  const safeStakeAmount = applySlippage(estimatedLiquidity, slippageBps);
 
   // Step 4 - Approve LP token (pool address) to Executor (skip if already approved)
   const lpAllowance: bigint = await withRetry(async () => {
@@ -209,10 +210,10 @@ export async function executeEnterStrategy(
     return lp.allowance(req.userAddress, executorAddress) as Promise<bigint>;
   }, 4, 800).catch((e) => { console.error(`[ENTER] LP allowance check FAILED:`, e instanceof Error ? e.message : e); return 0n; });
   console.log(`[ENTER] LP allowance=${lpAllowance.toString()}, needed=${estimatedLiquidity.toString()}, skip=${lpAllowance >= estimatedLiquidity}`);
-  if (lpAllowance < estimatedLiquidity) {
+  if (lpAllowance < safeStakeAmount) {
     steps.push({
       to: poolAddress,
-      data: erc20Iface.encodeFunctionData("approve", [executorAddress, ethers.MaxUint256]),
+      data: erc20Iface.encodeFunctionData("approve", [executorAddress, safeStakeAmount]),
       value: "0",
       chainId: chain.chainId,
       description: "Approve LP token",
@@ -220,8 +221,6 @@ export async function executeEnterStrategy(
   }
 
   // Step 5 - Stake LP in Gauge via PanoramaExecutor
-  // Use slippage-adjusted LP amount to account for difference between quote and actual
-  const safeStakeAmount = applySlippage(estimatedLiquidity, slippageBps);
   const stakeExtraData = ethers.AbiCoder.defaultAbiCoder().encode(["address"], [gaugeAddress]);
 
   steps.push({

--- a/backend/src/modules/liquid-staking/usecases/prepare-exit-strategy.usecase.ts
+++ b/backend/src/modules/liquid-staking/usecases/prepare-exit-strategy.usecase.ts
@@ -5,14 +5,15 @@ import { getStakingPoolById } from "../config/staking-pools";
 import { getPoolAddress } from "../../../providers/aerodrome.provider";
 import { getGaugeForPool, getStakedBalance } from "../../../providers/gauge.provider";
 import { getContract } from "../../../providers/chain.provider";
-import { PANORAMA_EXECUTOR_ABI, ERC20_ABI } from "../../../utils/abi";
-import { encodeProtocolId, getDeadline } from "../../../utils/encoding";
+import { PANORAMA_EXECUTOR_ABI, ERC20_ABI, POOL_ABI } from "../../../utils/abi";
+import { applySlippage, encodeProtocolId, getDeadline } from "../../../utils/encoding";
 import { PreparedTransaction, TransactionBundle } from "../../../types/transaction";
 
 export interface PrepareExitStrategyRequest {
   userAddress: string;
   poolId: string;
   amount?: string; // LP amount in wei. If omitted, exits full position.
+  slippageBps?: number;
   deadlineMinutes?: number;
 }
 
@@ -39,6 +40,7 @@ export async function executeExitStrategy(
 
   const chain = getChainConfig("base");
   const executorAddress = chain.contracts.panoramaExecutor;
+  const slippageBps = req.slippageBps ?? 100;
   const deadlineMinutes = req.deadlineMinutes ?? 20;
 
   // Resolve pool and gauge addresses on-chain
@@ -70,6 +72,18 @@ export async function executeExitStrategy(
     throw new Error(`Insufficient staked balance. Have: ${stakedBalance.toString()}, requested: ${lpAmount.toString()}`);
   }
 
+  const poolContract = getContract(poolAddress, POOL_ABI, "base");
+  const lpContract = getContract(poolAddress, ERC20_ABI, "base");
+  const [[reserve0, reserve1], totalSupply] = await Promise.all([
+    poolContract.getReserves() as Promise<[bigint, bigint, bigint]>,
+    lpContract.totalSupply() as Promise<bigint>,
+  ]);
+  if (totalSupply === 0n) {
+    throw new Error(`Pool ${poolConfig.name} has zero LP supply`);
+  }
+  const amountAMin = applySlippage((reserve0 * lpAmount) / totalSupply, slippageBps);
+  const amountBMin = applySlippage((reserve1 * lpAmount) / totalSupply, slippageBps);
+
   const steps: PreparedTransaction[] = [];
   const erc20Iface = new ethers.Interface(ERC20_ABI);
   const executorIface = new ethers.Interface(PANORAMA_EXECUTOR_ABI);
@@ -93,7 +107,6 @@ export async function executeExitStrategy(
   });
 
   // Step 2 - Approve LP token to Executor for removeLiquidity
-  const lpContract = getContract(poolAddress, ERC20_ABI, "base");
   const currentAllowance: bigint = await lpContract.allowance(req.userAddress, executorAddress);
   if (currentAllowance < lpAmount) {
     steps.push({
@@ -116,8 +129,8 @@ export async function executeExitStrategy(
       poolConfig.tokenB.address,
       poolConfig.stable,
       lpAmount,
-      BigInt(0), // amountAMin - 0 for simplicity, frontend can adjust
-      BigInt(0), // amountBMin
+      amountAMin,
+      amountBMin,
       removeExtraData,
       deadline,
     ]),

--- a/backend/src/modules/swap/routes/swap.routes.ts
+++ b/backend/src/modules/swap/routes/swap.routes.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { prepareSwap, getQuote, getSwapPairs, submitSwapTx, getSwapTxStatus, getSwapHistory } from "../controllers/swap.controller";
 import { asyncHandler } from "../../../middleware/errorHandler";
 import { validateAddress, validateAmount, validateRequired, validateSlippage, validateTxHash } from "../../../middleware/validation";
+import { requireSignedHistoryAccess, requireSignedTxSubmission } from "../../../middleware/auth";
 
 export const swapRoutes = Router();
 
@@ -29,6 +30,7 @@ swapRoutes.post("/transaction/submit",
   validateRequired("txHash", "userAddress"),
   validateTxHash("txHash"),
   validateAddress("userAddress"),
+  requireSignedTxSubmission("swap"),
   asyncHandler(submitSwapTx)
 );
 
@@ -39,5 +41,6 @@ swapRoutes.get("/transaction/:txHash",
 
 swapRoutes.get("/history/:userAddress",
   validateAddress("userAddress", "params"),
+  requireSignedHistoryAccess("swap"),
   asyncHandler(getSwapHistory)
 );

--- a/backend/src/modules/swap/usecases/get-quote.usecase.ts
+++ b/backend/src/modules/swap/usecases/get-quote.usecase.ts
@@ -1,5 +1,6 @@
 import { getQuote } from "../../../providers/aerodrome.provider";
 import { applySlippage } from "../../../utils/encoding";
+import { formatExchangeRate } from "../../../utils/tokenMath";
 
 export interface SwapQuoteRequest {
   tokenIn: string;
@@ -27,11 +28,7 @@ export async function executeGetSwapQuote(req: SwapQuoteRequest): Promise<SwapQu
 
   const { amountOut } = await getQuote(req.tokenIn, req.tokenOut, amountIn, stable);
   const amountOutMin = applySlippage(amountOut, slippageBps);
-
-  const exchangeRate =
-    amountIn > 0n
-      ? (Number(amountOut) / Number(amountIn)).toFixed(8)
-      : "0";
+  const exchangeRate = await formatExchangeRate(req.tokenIn, req.tokenOut, amountIn, amountOut, 8);
 
   return {
     tokenIn: req.tokenIn,

--- a/backend/src/modules/swap/usecases/prepare-swap.usecase.ts
+++ b/backend/src/modules/swap/usecases/prepare-swap.usecase.ts
@@ -11,6 +11,7 @@ import {
   applySlippage,
 } from "../../../utils/encoding";
 import { PreparedTransaction, TransactionBundle } from "../../../types/transaction";
+import { formatExchangeRate } from "../../../utils/tokenMath";
 
 export interface PrepareSwapRequest {
   userAddress: string;
@@ -32,6 +33,7 @@ export interface PrepareSwapResponse {
     amountOutMin: string;
     stable: boolean;
     slippageBps: number;
+    exchangeRate: string;
     priceImpact: string;
   };
 }
@@ -92,10 +94,7 @@ export async function executePrepareSwapBundle(
     description: `Swap via Aerodrome`,
   });
 
-  const priceImpact =
-    amountIn > 0n
-      ? (100 - (Number(amountOut) / Number(amountIn)) * 100).toFixed(4)
-      : "0";
+  const exchangeRate = await formatExchangeRate(req.tokenIn, req.tokenOut, amountIn, amountOut, 8);
 
   return {
     bundle: {
@@ -111,7 +110,8 @@ export async function executePrepareSwapBundle(
       amountOutMin: amountOutMin.toString(),
       stable,
       slippageBps,
-      priceImpact,
+      priceImpact: "derived from route quote; exact impact computed at execution",
+      exchangeRate,
     },
   };
 }

--- a/backend/src/shared/errorCodes.ts
+++ b/backend/src/shared/errorCodes.ts
@@ -6,6 +6,7 @@ export const ErrorCodes = {
   MISSING_FIELD: { code: "MISSING_FIELD", status: 400, message: "Missing required field" },
   INVALID_POOL_ID: { code: "INVALID_POOL_ID", status: 400, message: "Invalid or unknown pool ID" },
   INVALID_SLIPPAGE: { code: "INVALID_SLIPPAGE", status: 400, message: "Slippage must be between 1 and 5000 bps" },
+  UNSUPPORTED_OPERATION: { code: "UNSUPPORTED_OPERATION", status: 400, message: "Requested operation is not supported" },
   INVALID_SIGNATURE: { code: "INVALID_SIGNATURE", status: 401, message: "Invalid wallet signature" },
   AUTH_EXPIRED: { code: "AUTH_EXPIRED", status: 401, message: "Authentication payload has expired" },
 

--- a/backend/src/shared/errorCodes.ts
+++ b/backend/src/shared/errorCodes.ts
@@ -6,6 +6,8 @@ export const ErrorCodes = {
   MISSING_FIELD: { code: "MISSING_FIELD", status: 400, message: "Missing required field" },
   INVALID_POOL_ID: { code: "INVALID_POOL_ID", status: 400, message: "Invalid or unknown pool ID" },
   INVALID_SLIPPAGE: { code: "INVALID_SLIPPAGE", status: 400, message: "Slippage must be between 1 and 5000 bps" },
+  INVALID_SIGNATURE: { code: "INVALID_SIGNATURE", status: 401, message: "Invalid wallet signature" },
+  AUTH_EXPIRED: { code: "AUTH_EXPIRED", status: 401, message: "Authentication payload has expired" },
 
   // Not found (404)
   POOL_NOT_FOUND: { code: "POOL_NOT_FOUND", status: 404, message: "Pool not found on-chain" },

--- a/backend/src/shared/transactionStore.ts
+++ b/backend/src/shared/transactionStore.ts
@@ -1,3 +1,6 @@
+import { existsSync, readFileSync } from "fs";
+import { mkdir, writeFile } from "fs/promises";
+import path from "path";
 import { getProvider } from "../providers/chain.provider";
 
 export type TxStatus = "pending" | "confirmed" | "failed";
@@ -16,10 +19,13 @@ export interface StoredTransaction {
   confirmedAt?: string;
 }
 
-// In-memory store — sufficient for hackathon MVP.
-// Production would use PostgreSQL.
+const STORE_DIR = path.resolve(process.cwd(), "data");
+const STORE_FILE = path.join(STORE_DIR, "transactions.json");
+
 const transactions = new Map<string, StoredTransaction>();
 const userIndex = new Map<string, string[]>(); // userAddress → txHash[]
+let storeLoaded = false;
+let persistChain: Promise<void> = Promise.resolve();
 
 export function submitTransaction(
   txHash: string,
@@ -28,6 +34,8 @@ export function submitTransaction(
   action: string,
   chainId: number = 8453
 ): StoredTransaction {
+  ensureLoaded();
+
   const tx: StoredTransaction = {
     txHash: txHash.toLowerCase(),
     userAddress: userAddress.toLowerCase(),
@@ -47,15 +55,18 @@ export function submitTransaction(
 
   // Fire-and-forget: poll for confirmation
   pollConfirmation(tx.txHash).catch(() => {});
+  void persistStore();
 
   return tx;
 }
 
 export function getTransaction(txHash: string): StoredTransaction | undefined {
+  ensureLoaded();
   return transactions.get(txHash.toLowerCase());
 }
 
 export function getUserTransactions(userAddress: string): StoredTransaction[] {
+  ensureLoaded();
   const hashes = userIndex.get(userAddress.toLowerCase()) ?? [];
   return hashes
     .map(h => transactions.get(h))
@@ -64,6 +75,7 @@ export function getUserTransactions(userAddress: string): StoredTransaction[] {
 }
 
 async function pollConfirmation(txHash: string, maxAttempts = 30): Promise<void> {
+  ensureLoaded();
   const provider = getProvider("base");
   for (let i = 0; i < maxAttempts; i++) {
     await new Promise(r => setTimeout(r, 5000));
@@ -77,10 +89,48 @@ async function pollConfirmation(txHash: string, maxAttempts = 30): Promise<void>
         tx.blockNumber = receipt.blockNumber;
         tx.gasUsed = receipt.gasUsed.toString();
         tx.confirmedAt = new Date().toISOString();
+        await persistStore();
         return;
       }
     } catch {
       // RPC error, keep polling
     }
   }
+}
+
+function ensureLoaded() {
+  if (storeLoaded) {
+    return;
+  }
+
+  storeLoaded = true;
+  loadStore();
+}
+
+function loadStore(): void {
+  try {
+    if (!existsSync(STORE_FILE)) {
+      return;
+    }
+    const raw = readFileSync(STORE_FILE, "utf8");
+    const parsed = JSON.parse(raw) as { transactions?: StoredTransaction[] };
+    for (const tx of parsed.transactions ?? []) {
+      transactions.set(tx.txHash, tx);
+      const list = userIndex.get(tx.userAddress) ?? [];
+      list.push(tx.txHash);
+      userIndex.set(tx.userAddress, list);
+    }
+  } catch {
+    // Missing or malformed store: start fresh.
+  }
+}
+
+async function persistStore(): Promise<void> {
+  const snapshot = JSON.stringify({ transactions: [...transactions.values()] }, null, 2);
+  persistChain = persistChain.then(async () => {
+    await mkdir(STORE_DIR, { recursive: true });
+    await writeFile(STORE_FILE, snapshot, "utf8");
+  }).catch(() => {});
+
+  await persistChain;
 }

--- a/backend/src/usecases/get-quote.usecase.ts
+++ b/backend/src/usecases/get-quote.usecase.ts
@@ -1,5 +1,5 @@
-import { ethers } from "ethers";
 import { getQuote } from "../providers/aerodrome.provider";
+import { formatExchangeRate } from "../utils/tokenMath";
 
 export interface QuoteRequest {
   tokenIn: string;
@@ -22,11 +22,7 @@ export async function executeGetQuote(req: QuoteRequest): Promise<QuoteResponse>
   const stable = req.stable ?? false;
 
   const { amountOut } = await getQuote(req.tokenIn, req.tokenOut, amountIn, stable);
-
-  const rate =
-    amountIn > 0n
-      ? (Number(amountOut) / Number(amountIn)).toFixed(6)
-      : "0";
+  const rate = await formatExchangeRate(req.tokenIn, req.tokenOut, amountIn, amountOut, 6);
 
   return {
     tokenIn: req.tokenIn,

--- a/backend/src/usecases/prepare-liquidity.usecase.ts
+++ b/backend/src/usecases/prepare-liquidity.usecase.ts
@@ -3,6 +3,7 @@ import { getChainConfig } from "../config/chains";
 import { PANORAMA_EXECUTOR_ABI } from "../utils/abi";
 import { encodeProtocolId, getDeadline, isNativeETH, applySlippage } from "../utils/encoding";
 import { PreparedTransaction } from "../types/transaction";
+import { AppError } from "../shared/errorCodes";
 
 export interface PrepareLiquidityRequest {
   tokenA: string;
@@ -23,6 +24,13 @@ export async function executePrepareAddLiquidity(
   const stable = req.stable ?? false;
   const slippageBps = req.slippageBps ?? 50;
   const deadlineMinutes = req.deadlineMinutes ?? 20;
+
+  if (isNativeETH(req.tokenA) || isNativeETH(req.tokenB)) {
+    throw new AppError(
+      "UNSUPPORTED_OPERATION",
+      "Native ETH liquidity is not supported by PanoramaExecutor; use ERC-20 token addresses only"
+    );
+  }
 
   const amountAMin = applySlippage(amountA, slippageBps);
   const amountBMin = applySlippage(amountB, slippageBps);
@@ -45,15 +53,10 @@ export async function executePrepareAddLiquidity(
     deadline,
   ]);
 
-  // If either token is native ETH, send its amount as value
-  let value = "0";
-  if (isNativeETH(req.tokenA)) value = amountA.toString();
-  else if (isNativeETH(req.tokenB)) value = amountB.toString();
-
   return {
     to: chain.contracts.panoramaExecutor,
     data,
-    value,
+    value: "0",
     chainId: chain.chainId,
   };
 }

--- a/backend/src/utils/abi.ts
+++ b/backend/src/utils/abi.ts
@@ -1,5 +1,6 @@
 export const PANORAMA_EXECUTOR_ABI = [
   "function executeSwap(bytes32 protocolId, address tokenIn, address tokenOut, uint256 amountIn, uint256 amountOutMin, bytes calldata extraData, uint256 deadline) external payable returns (uint256 amountOut)",
+  "function executeSwapFor(bytes32 protocolId, address adapterOwner, address tokenPayer, address tokenIn, address tokenOut, uint256 amountIn, uint256 amountOutMin, address recipient, bytes calldata extraData, uint256 deadline) external payable returns (uint256 amountOut)",
   "function executeAddLiquidity(bytes32 protocolId, address tokenA, address tokenB, bool stable, uint256 amountADesired, uint256 amountBDesired, uint256 amountAMin, uint256 amountBMin, bytes calldata extraData, uint256 deadline) external payable returns (uint256 liquidity)",
   "function executeRemoveLiquidity(bytes32 protocolId, address tokenA, address tokenB, bool stable, uint256 liquidity, uint256 amountAMin, uint256 amountBMin, bytes calldata extraData, uint256 deadline) external returns (uint256 amountA, uint256 amountB)",
   "function executeStake(bytes32 protocolId, address lpToken, uint256 amount, bytes calldata extraData) external",
@@ -27,6 +28,7 @@ export const ERC20_ABI = [
   "function balanceOf(address) external view returns (uint256)",
   "function decimals() external view returns (uint8)",
   "function symbol() external view returns (string)",
+  "function totalSupply() external view returns (uint256)",
   "function allowance(address owner, address spender) external view returns (uint256)",
   "function approve(address spender, uint256 amount) external returns (bool)",
 ] as const;

--- a/backend/src/utils/tokenMath.ts
+++ b/backend/src/utils/tokenMath.ts
@@ -1,0 +1,61 @@
+import { getContract } from "../providers/chain.provider";
+import { ERC20_ABI } from "./abi";
+import { isNativeETH } from "./encoding";
+
+const DECIMAL_CACHE = new Map<string, number>();
+
+export async function getTokenDecimals(token: string, chain: string = "base"): Promise<number> {
+  if (isNativeETH(token)) {
+    return 18;
+  }
+
+  const key = `${chain}:${token.toLowerCase()}`;
+  const cached = DECIMAL_CACHE.get(key);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const contract = getContract(token, ERC20_ABI, chain);
+  const decimals = Number(await contract.decimals());
+  DECIMAL_CACHE.set(key, decimals);
+  return decimals;
+}
+
+export async function formatExchangeRate(
+  tokenIn: string,
+  tokenOut: string,
+  amountIn: bigint,
+  amountOut: bigint,
+  precision: number = 8
+): Promise<string> {
+  if (amountIn === 0n) {
+    return "0";
+  }
+
+  const [decimalsIn, decimalsOut] = await Promise.all([
+    getTokenDecimals(tokenIn),
+    getTokenDecimals(tokenOut),
+  ]);
+
+  const scale = 10n ** BigInt(precision);
+  const numerator = amountOut * (10n ** BigInt(decimalsIn)) * scale;
+  const denominator = amountIn * (10n ** BigInt(decimalsOut));
+  const scaledRate = denominator === 0n ? 0n : numerator / denominator;
+
+  return formatFixed(scaledRate, precision);
+}
+
+function formatFixed(value: bigint, decimals: number): string {
+  if (decimals === 0) {
+    return value.toString();
+  }
+
+  const base = 10n ** BigInt(decimals);
+  const integerPart = value / base;
+  let fractionalPart = (value % base).toString().padStart(decimals, "0");
+  fractionalPart = fractionalPart.replace(/0+$/, "");
+
+  return fractionalPart.length > 0
+    ? `${integerPart.toString()}.${fractionalPart}`
+    : integerPart.toString();
+}

--- a/contracts/core/DCAVault.sol
+++ b/contracts/core/DCAVault.sol
@@ -38,8 +38,14 @@ contract DCAVault {
     // ========== STATE ==========
 
     address public owner;
+    address public pendingOwner;
+    uint256 public ownershipTransferUnlockAt;
     address public keeper;
+    address public pendingKeeper;
+    uint256 public keeperChangeUnlockAt;
     address public executor;     // PanoramaExecutor
+
+    uint256 public constant ADMIN_DELAY = 1 days;
 
     uint256 public nextOrderId;
     mapping(uint256 => Order) public orders;
@@ -66,6 +72,9 @@ contract DCAVault {
     event Deposited(uint256 indexed orderId, address indexed owner, uint256 amount);
     event Withdrawn(uint256 indexed orderId, address indexed owner, uint256 amount);
     event KeeperUpdated(address indexed oldKeeper, address indexed newKeeper);
+    event KeeperChangeScheduled(address indexed oldKeeper, address indexed newKeeper, uint256 executeAfter);
+    event OwnershipTransferStarted(address indexed currentOwner, address indexed pendingOwner, uint256 executeAfter);
+    event OwnershipTransferred(address indexed oldOwner, address indexed newOwner);
 
     // ========== ERRORS ==========
 
@@ -79,6 +88,7 @@ contract DCAVault {
     error ZeroAddress();
     error ZeroInterval();
     error Reentrancy();
+    error DelayNotElapsed();
 
     // ========== MODIFIERS ==========
 
@@ -243,20 +253,28 @@ contract DCAVault {
         // Build protocolId for aerodrome
         bytes32 protocolId = keccak256(abi.encodePacked("aerodrome"));
 
-        // Call PanoramaExecutor.executeSwap — tokenOut goes to order owner
-        (bool success,) = executor.call(
+        // Call PanoramaExecutor.executeSwapFor so funds come from this vault
+        // while the position and proceeds remain attributed to the order owner.
+        (bool success, bytes memory returndata) = executor.call(
             abi.encodeWithSignature(
-                "executeSwap(bytes32,address,address,uint256,uint256,bytes,uint256)",
+                "executeSwapFor(bytes32,address,address,address,address,uint256,uint256,address,bytes,uint256)",
                 protocolId,
+                order.owner,
+                address(this),
                 order.tokenIn,
                 order.tokenOut,
                 order.amountPerSwap,
                 amountOutMin,
+                order.owner,
                 extraData,
                 deadline
             )
         );
-        require(success, "DCAVault: swap failed");
+        if (!success) {
+            assembly {
+                revert(add(returndata, 0x20), mload(returndata))
+            }
+        }
 
         emit OrderExecuted(orderId, order.owner, order.amountPerSwap, block.timestamp);
     }
@@ -299,13 +317,35 @@ contract DCAVault {
 
     function setKeeper(address newKeeper) external onlyOwner {
         if (newKeeper == address(0)) revert ZeroAddress();
-        emit KeeperUpdated(keeper, newKeeper);
-        keeper = newKeeper;
+        pendingKeeper = newKeeper;
+        keeperChangeUnlockAt = block.timestamp + ADMIN_DELAY;
+        emit KeeperChangeScheduled(keeper, newKeeper, keeperChangeUnlockAt);
+    }
+
+    function executeKeeperChange() external onlyOwner {
+        if (pendingKeeper == address(0)) revert ZeroAddress();
+        if (block.timestamp < keeperChangeUnlockAt) revert DelayNotElapsed();
+        emit KeeperUpdated(keeper, pendingKeeper);
+        keeper = pendingKeeper;
+        pendingKeeper = address(0);
+        keeperChangeUnlockAt = 0;
     }
 
     function transferOwnership(address newOwner) external onlyOwner {
         if (newOwner == address(0)) revert ZeroAddress();
-        owner = newOwner;
+        pendingOwner = newOwner;
+        ownershipTransferUnlockAt = block.timestamp + ADMIN_DELAY;
+        emit OwnershipTransferStarted(owner, newOwner, ownershipTransferUnlockAt);
+    }
+
+    function acceptOwnership() external {
+        if (msg.sender != pendingOwner) revert Unauthorized();
+        if (block.timestamp < ownershipTransferUnlockAt) revert DelayNotElapsed();
+        address oldOwner = owner;
+        owner = pendingOwner;
+        pendingOwner = address(0);
+        ownershipTransferUnlockAt = 0;
+        emit OwnershipTransferred(oldOwner, owner);
     }
 
     // ========== INTERNAL ==========

--- a/contracts/core/PanoramaExecutor.sol
+++ b/contracts/core/PanoramaExecutor.sol
@@ -20,17 +20,43 @@ contract PanoramaExecutor {
     // ========== STATE ==========
 
     address public owner;
+    address public pendingOwner;
+    uint256 public ownershipTransferUnlockAt;
     /// @notice Implementation contracts for each protocol (used as clone templates)
     mapping(bytes32 => address) public adapterImplementations;
     /// @notice Per-user adapter clones: protocolId => user => clone address
     mapping(bytes32 => mapping(address => address)) public userAdapters;
+    /// @notice Trusted operators that may execute swaps on behalf of a user (e.g. DCA vaults).
+    mapping(address => bool) public authorizedOperators;
+    mapping(address => PendingOperatorChange) public pendingOperatorChanges;
+    mapping(bytes32 => PendingAdapterRemoval) public pendingAdapterRemovals;
     bool private _locked;
+
+    uint256 public constant ADMIN_DELAY = 1 days;
+
+    struct PendingOperatorChange {
+        bool authorized;
+        uint256 executeAfter;
+        bool exists;
+    }
+
+    struct PendingAdapterRemoval {
+        uint256 executeAfter;
+        bool exists;
+    }
 
     // ========== EVENTS ==========
 
     event AdapterRegistered(bytes32 indexed protocolId, address indexed implementation);
     event AdapterRemoved(bytes32 indexed protocolId, address indexed oldImplementation);
     event UserAdapterCreated(address indexed user, bytes32 indexed protocolId, address adapter);
+    event OwnershipTransferStarted(address indexed currentOwner, address indexed pendingOwner, uint256 executeAfter);
+    event OwnershipTransferred(address indexed oldOwner, address indexed newOwner);
+    event OperatorChangeScheduled(address indexed operator, bool authorized, uint256 executeAfter);
+    event OperatorChangeCancelled(address indexed operator);
+    event OperatorChangeExecuted(address indexed operator, bool authorized);
+    event AdapterRemovalScheduled(bytes32 indexed protocolId, uint256 executeAfter);
+    event AdapterRemovalCancelled(bytes32 indexed protocolId);
     event SwapExecuted(
         address indexed user,
         bytes32 indexed protocolId,
@@ -70,6 +96,10 @@ contract PanoramaExecutor {
     error TransferFailed();
     error Reentrancy();
     error ZeroAddress();
+    error InvalidToken();
+    error AlreadyRegistered();
+    error DelayNotElapsed();
+    error NoPendingChange();
 
     // ========== MODIFIERS ==========
 
@@ -90,6 +120,11 @@ contract PanoramaExecutor {
         _;
     }
 
+    modifier onlyAuthorizedOperator() {
+        if (!authorizedOperators[msg.sender]) revert Unauthorized();
+        _;
+    }
+
     // ========== CONSTRUCTOR ==========
 
     constructor() {
@@ -105,14 +140,18 @@ contract PanoramaExecutor {
      *      but has its own storage, so each user gets isolated gauge positions and rewards.
      */
     function _getOrCreateUserAdapter(bytes32 protocolId) internal returns (address adapter) {
-        adapter = userAdapters[protocolId][msg.sender];
+        return _getOrCreateUserAdapterFor(protocolId, msg.sender);
+    }
+
+    function _getOrCreateUserAdapterFor(bytes32 protocolId, address user) internal returns (address adapter) {
+        adapter = userAdapters[protocolId][user];
         if (adapter == address(0)) {
             address implementation = adapterImplementations[protocolId];
             if (implementation == address(0)) revert AdapterNotRegistered();
-            bytes32 salt = keccak256(abi.encodePacked(msg.sender, protocolId));
+            bytes32 salt = keccak256(abi.encodePacked(user, protocolId));
             adapter = Clones.cloneDeterministic(implementation, salt);
-            userAdapters[protocolId][msg.sender] = adapter;
-            emit UserAdapterCreated(msg.sender, protocolId, adapter);
+            userAdapters[protocolId][user] = adapter;
+            emit UserAdapterCreated(user, protocolId, adapter);
         }
     }
 
@@ -164,6 +203,35 @@ contract PanoramaExecutor {
         emit SwapExecuted(msg.sender, protocolId, tokenIn, tokenOut, amountIn, amountOut);
     }
 
+    /**
+     * @notice Execute a swap funded by a trusted operator while preserving the end user's adapter isolation.
+     * @dev Used by automation contracts such as DCAVault. Tokens are pulled from `tokenPayer`,
+     *      positions remain attributed to `adapterOwner`, and swap proceeds are sent to `recipient`.
+     */
+    function executeSwapFor(
+        bytes32 protocolId,
+        address adapterOwner,
+        address tokenPayer,
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address recipient,
+        bytes calldata extraData,
+        uint256 deadline
+    ) external payable nonReentrant beforeDeadline(deadline) onlyAuthorizedOperator returns (uint256 amountOut) {
+        if (adapterOwner == address(0) || tokenPayer == address(0) || recipient == address(0)) revert ZeroAddress();
+        if (tokenIn == address(0)) revert InvalidToken();
+        if (amountIn == 0) revert InvalidAmount();
+
+        address adapter = _getOrCreateUserAdapterFor(protocolId, adapterOwner);
+        tokenIn.safeTransferFrom(tokenPayer, adapter, amountIn);
+        amountOut = IProtocolAdapter(adapter).swap(tokenIn, tokenOut, amountIn, amountOutMin, recipient, extraData);
+
+        if (amountOut < amountOutMin) revert InsufficientOutput();
+        emit SwapExecuted(adapterOwner, protocolId, tokenIn, tokenOut, amountIn, amountOut);
+    }
+
     // ========== LIQUIDITY ==========
 
     function executeAddLiquidity(
@@ -179,6 +247,7 @@ contract PanoramaExecutor {
         uint256 deadline
     ) external payable nonReentrant beforeDeadline(deadline) returns (uint256 liquidity) {
         if (amountADesired == 0 || amountBDesired == 0) revert InvalidAmount();
+        if (tokenA == address(0) || tokenB == address(0)) revert InvalidToken();
         address adapter = _getOrCreateUserAdapter(protocolId);
 
         tokenA.safeTransferFrom(msg.sender, adapter, amountADesired);
@@ -203,6 +272,7 @@ contract PanoramaExecutor {
         uint256 deadline
     ) external nonReentrant beforeDeadline(deadline) returns (uint256 amountA, uint256 amountB) {
         if (liquidity == 0) revert InvalidAmount();
+        if (tokenA == address(0) || tokenB == address(0)) revert InvalidToken();
         address adapter = _getOrCreateUserAdapter(protocolId);
 
         address pool = abi.decode(extraData, (address));
@@ -266,19 +336,74 @@ contract PanoramaExecutor {
      */
     function registerAdapter(bytes32 protocolId, address implementation) external onlyOwner {
         if (implementation == address(0)) revert ZeroAddress();
+        if (adapterImplementations[protocolId] != address(0)) revert AlreadyRegistered();
         adapterImplementations[protocolId] = implementation;
         emit AdapterRegistered(protocolId, implementation);
     }
 
+    function setAuthorizedOperator(address operator, bool authorized) external onlyOwner {
+        if (operator == address(0)) revert ZeroAddress();
+        pendingOperatorChanges[operator] = PendingOperatorChange({
+            authorized: authorized,
+            executeAfter: block.timestamp + ADMIN_DELAY,
+            exists: true
+        });
+        emit OperatorChangeScheduled(operator, authorized, block.timestamp + ADMIN_DELAY);
+    }
+
+    function executeAuthorizedOperatorChange(address operator) external onlyOwner {
+        PendingOperatorChange memory change = pendingOperatorChanges[operator];
+        if (!change.exists) revert NoPendingChange();
+        if (block.timestamp < change.executeAfter) revert DelayNotElapsed();
+        authorizedOperators[operator] = change.authorized;
+        delete pendingOperatorChanges[operator];
+        emit OperatorChangeExecuted(operator, change.authorized);
+    }
+
+    function cancelAuthorizedOperatorChange(address operator) external onlyOwner {
+        if (!pendingOperatorChanges[operator].exists) revert NoPendingChange();
+        delete pendingOperatorChanges[operator];
+        emit OperatorChangeCancelled(operator);
+    }
+
     function removeAdapter(bytes32 protocolId) external onlyOwner {
+        if (adapterImplementations[protocolId] == address(0)) revert AdapterNotRegistered();
+        pendingAdapterRemovals[protocolId] =
+            PendingAdapterRemoval({executeAfter: block.timestamp + ADMIN_DELAY, exists: true});
+        emit AdapterRemovalScheduled(protocolId, block.timestamp + ADMIN_DELAY);
+    }
+
+    function executeAdapterRemoval(bytes32 protocolId) external onlyOwner {
+        PendingAdapterRemoval memory pending = pendingAdapterRemovals[protocolId];
+        if (!pending.exists) revert NoPendingChange();
+        if (block.timestamp < pending.executeAfter) revert DelayNotElapsed();
         address old = adapterImplementations[protocolId];
         delete adapterImplementations[protocolId];
+        delete pendingAdapterRemovals[protocolId];
         emit AdapterRemoved(protocolId, old);
+    }
+
+    function cancelAdapterRemoval(bytes32 protocolId) external onlyOwner {
+        if (!pendingAdapterRemovals[protocolId].exists) revert NoPendingChange();
+        delete pendingAdapterRemovals[protocolId];
+        emit AdapterRemovalCancelled(protocolId);
     }
 
     function transferOwnership(address newOwner) external onlyOwner {
         if (newOwner == address(0)) revert ZeroAddress();
-        owner = newOwner;
+        pendingOwner = newOwner;
+        ownershipTransferUnlockAt = block.timestamp + ADMIN_DELAY;
+        emit OwnershipTransferStarted(owner, newOwner, ownershipTransferUnlockAt);
+    }
+
+    function acceptOwnership() external {
+        if (msg.sender != pendingOwner) revert Unauthorized();
+        if (block.timestamp < ownershipTransferUnlockAt) revert DelayNotElapsed();
+        address oldOwner = owner;
+        owner = pendingOwner;
+        pendingOwner = address(0);
+        ownershipTransferUnlockAt = 0;
+        emit OwnershipTransferred(oldOwner, owner);
     }
 
     function emergencyWithdraw() external onlyOwner {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -787,7 +787,8 @@ async function loadProtocolInfo() {
       <div class="pool-detail" style="margin-bottom:12px"><strong>${data.protocol}</strong> on ${data.chain} — Updated: ${new Date(data.updatedAt).toLocaleTimeString()}</div>
       ${pools.map(p => `
         <div class="pool-item">
-          <div class="pool-name">${p.poolName} <span class="badge badge-apr">APR ${p.estimatedAPR}</span></div>
+          <div class="pool-name">${p.poolName} <span class="badge badge-apr">Fee APR ${p.estimatedAPR}</span></div>
+          <div class="pool-detail">${p.aprDisclaimer || ""}</div>
           <div class="pool-detail">Total Staked: ${parseFloat(ethers.formatEther(p.totalStaked)).toFixed(4)} LP</div>
           <div class="pool-detail">Reward Rate: ${parseFloat(ethers.formatEther(p.rewardRatePerSecond)).toFixed(8)} /s</div>
           <div class="pool-detail">Pool: <a href="https://basescan.org/address/${p.poolAddress}" target="_blank">${p.poolAddress.slice(0,10)}...${p.poolAddress.slice(-8)}</a></div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -387,10 +387,20 @@ async function ensureConnected() {
 async function trackTx(txHash, module, action) {
   if (!userAddress) return;
   try {
+    const timestamp = Date.now();
+    const message = [
+      "PanoramaBlock transaction submission",
+      `module:${module}`,
+      `user:${userAddress.toLowerCase()}`,
+      `txHash:${txHash.toLowerCase()}`,
+      `action:${action || module}`,
+      `timestamp:${timestamp}`,
+    ].join("\n");
+    const signature = await signer.signMessage(message);
     await fetch(`${API}/${module}/transaction/submit`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ txHash, userAddress, action }),
+      body: JSON.stringify({ txHash, userAddress, action, timestamp, signature }),
     });
   } catch {
     // Non-critical — tracking is best-effort
@@ -792,10 +802,22 @@ async function loadProtocolInfo() {
 async function loadAllHistory() {
   if (!userAddress) return;
   try {
+    const timestamp = Date.now();
+    const historySignature = async (module) => signer.signMessage([
+      "PanoramaBlock history access",
+      `module:${module}`,
+      `user:${userAddress.toLowerCase()}`,
+      `timestamp:${timestamp}`,
+    ].join("\n"));
+    const [stakingSig, swapSig, dcaSig] = await Promise.all([
+      historySignature("staking"),
+      historySignature("swap"),
+      historySignature("dca"),
+    ]);
     const [stakingRes, swapRes, dcaRes] = await Promise.all([
-      fetch(`${API}/staking/history/${userAddress}`).then(r => r.json()).catch(() => ({ transactions: [] })),
-      fetch(`${API}/swap/history/${userAddress}`).then(r => r.json()).catch(() => ({ transactions: [] })),
-      fetch(`${API}/dca/history/${userAddress}`).then(r => r.json()).catch(() => ({ transactions: [] })),
+      fetch(`${API}/staking/history/${userAddress}?timestamp=${timestamp}&signature=${encodeURIComponent(stakingSig)}`).then(r => r.json()).catch(() => ({ transactions: [] })),
+      fetch(`${API}/swap/history/${userAddress}?timestamp=${timestamp}&signature=${encodeURIComponent(swapSig)}`).then(r => r.json()).catch(() => ({ transactions: [] })),
+      fetch(`${API}/dca/history/${userAddress}?timestamp=${timestamp}&signature=${encodeURIComponent(dcaSig)}`).then(r => r.json()).catch(() => ({ transactions: [] })),
     ]);
 
     const all = [

--- a/script/DeployDCAVault.s.sol
+++ b/script/DeployDCAVault.s.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.20;
 
 import "forge-std/Script.sol";
 import {DCAVault} from "../contracts/core/DCAVault.sol";
+import {PanoramaExecutor} from "../contracts/core/PanoramaExecutor.sol";
 
 /**
  * @title DeployDCAVault
@@ -23,6 +24,7 @@ contract DeployDCAVault is Script {
 
         // Keeper = deployer wallet (change to dedicated keeper address if needed)
         DCAVault vault = new DCAVault(deployer, EXECUTOR);
+        PanoramaExecutor(payable(EXECUTOR)).setAuthorizedOperator(address(vault), true);
 
         vm.stopBroadcast();
 
@@ -31,7 +33,11 @@ contract DeployDCAVault is Script {
         console.log("Vault:   ", address(vault));
         console.log("Keeper:  ", deployer);
         console.log("Executor:", EXECUTOR);
-        console.log("\nNext step: add to backend/.env:");
+        console.log("\nNext step after 24h delay:");
+        console.log(
+            "call executeAuthorizedOperatorChange(vault) on PanoramaExecutor to activate DCA automation"
+        );
+        console.log("\nThen add to backend/.env:");
         console.log("DCA_VAULT_ADDRESS=", address(vault));
     }
 }

--- a/test/DCAVault.t.sol
+++ b/test/DCAVault.t.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import {PanoramaExecutor} from "../contracts/core/PanoramaExecutor.sol";
+import {AerodromeAdapter} from "../contracts/adapters/AerodromeAdapter.sol";
+import {DCAVault} from "../contracts/core/DCAVault.sol";
+import {MockERC20} from "./mocks/MockERC20.sol";
+import {MockRouter} from "./mocks/MockRouter.sol";
+
+contract DCAVaultTest is Test {
+    PanoramaExecutor public executor;
+    AerodromeAdapter public adapter;
+    DCAVault public vault;
+    MockRouter public mockRouter;
+    MockERC20 public tokenIn;
+    MockERC20 public tokenOut;
+    MockERC20 public weth;
+
+    address public owner = address(this);
+    address public keeper = address(0xCAFE);
+    address public user = address(0xBEEF);
+
+    bytes32 public constant AERODROME_ID = keccak256("aerodrome");
+
+    function setUp() public {
+        tokenIn = new MockERC20("Token In", "TIN", 18);
+        tokenOut = new MockERC20("Token Out", "TOUT", 6);
+        weth = new MockERC20("Wrapped ETH", "WETH", 18);
+        mockRouter = new MockRouter(address(weth), address(0xFACE));
+
+        executor = new PanoramaExecutor();
+        adapter = new AerodromeAdapter(address(mockRouter), address(0xDEAD), address(executor));
+        executor.registerAdapter(AERODROME_ID, address(adapter));
+
+        vault = new DCAVault(keeper, address(executor));
+        executor.setAuthorizedOperator(address(vault), true);
+        vm.warp(block.timestamp + executor.ADMIN_DELAY());
+        executor.executeAuthorizedOperatorChange(address(vault));
+
+        tokenIn.mint(user, 1000e18);
+    }
+
+    function test_Execute_UsesUserAdapterAndPaysUser() public {
+        uint256 depositAmount = 100e18;
+        uint256 swapAmount = 25e18;
+
+        vm.startPrank(user);
+        tokenIn.approve(address(vault), depositAmount);
+        uint256 orderId = vault.createOrder(address(tokenIn), address(tokenOut), swapAmount, 1 hours, 4, false, depositAmount);
+        vm.stopPrank();
+
+        assertEq(orderId, 0);
+        assertEq(tokenOut.balanceOf(user), 0);
+        assertEq(executor.getUserAdapter(AERODROME_ID, user), address(0));
+        assertEq(executor.getUserAdapter(AERODROME_ID, address(vault)), address(0));
+
+        vm.warp(block.timestamp + 1 hours);
+        vm.prank(keeper);
+        vault.execute(orderId, 0, abi.encode(false), block.timestamp + 1 hours);
+
+        address userAdapter = executor.getUserAdapter(AERODROME_ID, user);
+        assertTrue(userAdapter != address(0), "user adapter should be created");
+        assertEq(executor.getUserAdapter(AERODROME_ID, address(vault)), address(0), "vault must not get its own adapter");
+        assertEq(tokenOut.balanceOf(user), swapAmount, "swap output should go to the order owner");
+
+        (, , , , , uint256 lastExecuted, uint256 remainingSwaps, uint256 balance, , bool active) = vault.orders(orderId);
+        assertGt(lastExecuted, 0, "order should be marked executed");
+        assertEq(remainingSwaps, 3, "remaining swaps should decrease");
+        assertEq(balance, depositAmount - swapAmount, "vault balance should decrease by one swap");
+        assertTrue(active, "order should remain active");
+    }
+}

--- a/test/PanoramaExecutor.t.sol
+++ b/test/PanoramaExecutor.t.sol
@@ -64,11 +64,21 @@ contract PanoramaExecutorTest is Test {
 
     function test_RemoveAdapter() public {
         executor.removeAdapter(AERODROME_ID);
+        vm.warp(block.timestamp + executor.ADMIN_DELAY());
+        executor.executeAdapterRemoval(AERODROME_ID);
         assertEq(executor.adapterImplementations(AERODROME_ID), address(0));
+    }
+
+    function test_RemoveAdapter_SchedulesFirst() public {
+        executor.removeAdapter(AERODROME_ID);
+        assertEq(executor.adapterImplementations(AERODROME_ID), address(adapter));
     }
 
     function test_TransferOwnership() public {
         executor.transferOwnership(user);
+        vm.warp(block.timestamp + executor.ADMIN_DELAY());
+        vm.prank(user);
+        executor.acceptOwnership();
         assertEq(executor.owner(), user);
     }
 
@@ -111,6 +121,40 @@ contract PanoramaExecutorTest is Test {
         vm.prank(user);
         vm.expectRevert(PanoramaExecutor.AdapterNotRegistered.selector);
         executor.executeSwap(keccak256("unknown"), address(tokenA), address(tokenB), 1e18, 0, "", block.timestamp + 1);
+    }
+
+    function test_ExecuteSwapFor_OnlyAuthorizedOperator() public {
+        vm.startPrank(user);
+        tokenA.approve(address(executor), 1e18);
+        vm.expectRevert(PanoramaExecutor.Unauthorized.selector);
+        executor.executeSwapFor(
+            AERODROME_ID, user, user, address(tokenA), address(tokenB), 1e18, 0, user, abi.encode(false), block.timestamp + 1
+        );
+        vm.stopPrank();
+    }
+
+    function test_ExecuteSwapFor_AuthorizedOperator_AfterDelay() public {
+        executor.setAuthorizedOperator(address(this), true);
+        vm.warp(block.timestamp + executor.ADMIN_DELAY());
+        executor.executeAuthorizedOperatorChange(address(this));
+
+        tokenA.mint(address(this), 5e18);
+        tokenA.approve(address(executor), 1e18);
+
+        uint256 amountOut = executor.executeSwapFor(
+            AERODROME_ID, user, address(this), address(tokenA), address(tokenB), 1e18, 0, user, abi.encode(false), block.timestamp + 1
+        );
+
+        assertEq(amountOut, 1e18);
+        assertEq(tokenB.balanceOf(user), 1000e18 + 1e18);
+    }
+
+    function test_ExecuteAddLiquidity_InvalidToken() public {
+        vm.prank(user);
+        vm.expectRevert(PanoramaExecutor.InvalidToken.selector);
+        executor.executeAddLiquidity(
+            AERODROME_ID, address(0), address(tokenB), false, 1e18, 1e18, 0, 0, "0x", block.timestamp + 1
+        );
     }
 
     // ========== EMERGENCY TESTS ==========


### PR DESCRIPTION
Summary
- Replace lossy Number-based quote math with bigint/decimal-aware formatting
- Tighten liquidity/staking slippage handling
- Reframe protocol APR output as fee APR estimate with disclaimer
- Update frontend copy to reflect fee APR semantics

Verification
- npm run build
- forge test --no-match-path 'test/fork/*'
