### PR TITLE
[#74–#78] Architecture Decision Records 001–005

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,18 @@ Always respond in **Brazilian Portuguese (pt-BR)**.
 
 Always read `README.md` at the project root before starting any task.
 
+## Architecture Decision Records (ADRs)
+
+Long-lived architectural commitments live in `docs/adr/`. Read these before designing any backend or cross-cutting change:
+
+- [ADR 001 — Backend-first architecture](docs/adr/001-backend-first-architecture.md) — protocol names live only in backend adapters; FE/agents/bot/gateway speak capability vocabulary
+- [ADR 002 — Capability + Provider abstraction](docs/adr/002-capability-provider-abstraction.md) — the five-layer pattern (port → adapter → facade → controller → DI) and canonical vocabulary
+- [ADR 003 — Lane and feature taxonomy](docs/adr/003-lane-feature-taxonomy.md) — the 18 closed Lanes and per-sprint Features used on the PanoramaBlock Planning board
+- [ADR 004 — Layer dependency rules](docs/adr/004-layer-dependency-rules.md) — `shared/capability/` is a sink; no cross-service imports; FE/agents talk HTTP
+- [ADR 005 — Chain onboarding model](docs/adr/005-chain-onboarding-model.md) — chains as manifest files; no chainId literals outside `shared/capability/chains/`
+
+New ADRs go in `docs/adr/00N-<slug>.md` following the same shape (Context / Decision / Consequences / References). Open them via PR with the relevant board card linked.
+
 ## Repository layout
 
 ```

--- a/docs/adr/001-backend-first-architecture.md
+++ b/docs/adr/001-backend-first-architecture.md
@@ -1,0 +1,66 @@
+# ADR 001 — Backend-first architecture
+
+- **Status:** Accepted
+- **Date:** 2026-05-22
+- **Deciders:** Panorama-Block engineering (Hugo, Coletto, Rizzi, Marcos)
+- **Related cards:** Panorama-Block/execution-layer#74
+- **Supersedes:** —
+- **Superseded by:** —
+
+## Context
+
+PanoramaBlock has grown into a polylithic system: 6 backend microservices, a smart-contract layer (Base + Avax), a Telegram mini-app + bot, and an LLM agent stack. Historically each surface exposed protocol-specific behaviour:
+
+- `liquid-swap-service` knows about Uniswap, Thirdweb-bridge, Aerodrome by name.
+- `lending-service` legacy code embeds Benqi paths.
+- The mini-app rewrites `/api/lending/benqi/*` to bypass a service that is about to be removed (cf. `REFACTOR_PLAN.md` Phase 4).
+- The Zico agents mention protocols literally in prompts (`"swap on uniswap"`), and break when a protocol is replaced.
+
+That drift made it expensive to add or replace any protocol: a new lending market touched 4–6 layers (backend service, agent prompts, mini-app feature, gateway proxy, Telegram bot command), with no single owner of the contract.
+
+This sprint introduces a **Capability + Provider** abstraction (see ADR 002) that makes "protocol" an implementation detail of the backend. To make that work as a long-lived guarantee — not just a refactor that decays — we need to commit to a directional principle: **the backend is the only place that knows protocol names; everything outside the backend speaks only the capability vocabulary.**
+
+## Decision
+
+The backend is the source of truth for the system architecture. The principle has three concrete commitments:
+
+1. **Protocol names live only inside backend adapters.** No frontend code, agent prompt, gateway route, bot command, or smart-contract metadata may mention `uniswap`, `lido`, `benqi`, `aerodrome`, `moonwell`, `traderjoe`, etc., except inside `backend/<service>/src/infrastructure/adapters/`. Agents and mini-app see only `capability` slugs (`swap`, `lending`, `staking`, `liquidity`, `bridge`, `automation`).
+
+2. **No edge layer rewrites a protocol-specific URL.** Constructs like the current `/api/lending/benqi/*` rewrite in `telegram/apps/miniapp/next.config.ts` are forbidden going forward. The mini-app calls `/v1/capability/<slug>/*` via the gateway; the gateway proxies to the backend service that hosts that capability. Provider selection happens inside the backend, never at the edge.
+
+3. **New protocols arrive as backend changes only.** Adding Moonwell lending or Trader Joe LP must be doable by registering a new provider in the existing capability service — without touching FE, agents, or bot. If a protocol cannot be added that way, the abstraction is broken and must be fixed before the protocol ships.
+
+## Consequences
+
+### Positive
+
+- Onboarding a new protocol becomes a 1-PR change (a new adapter + a config entry), not a 4-repo coordinated change.
+- The FE bundle does not regress when a protocol is added or replaced — no rebuild required for a provider swap.
+- Agents stay coherent across protocol turnover: replacing Benqi with Aave does not retrain the prompt.
+- Single owner for protocol behaviour (backend) ⇒ single place to apply security review, rate limiting, observability.
+- The `REFACTOR_PLAN.md` Phase 4 (delete `lending-service`, `avax-service`, `diagram-service`) becomes safe because consumers have migrated to capability endpoints.
+
+### Negative
+
+- Cleanup cost is front-loaded: existing protocol-mentioning code in FE, agents, and edge config must be migrated before this principle is enforceable.
+- Slightly longer indirection on a hot-path request (FE → gateway → backend → registry → policy → adapter → SDK). The end-to-end latency budget should track this; if a capability's p95 regresses past +20 ms, that's a signal to re-examine the policy implementation, not to bypass the abstraction.
+- Discovery becomes load-bearing: if `/v1/capability/_discovery` is down or stale, the FE either over-restricts the UI or shows a broken option. Discovery requires its own SLA (cf. ADR 002 §"Discovery").
+
+### Neutral
+
+- Smart contracts may still reference protocol-specific adapter contracts on-chain (e.g. `AerodromeAdapterV2.sol`). On-chain registration is done by the backend deploy script (see SPRINT_HUGO.md Bloco 6), but the on-chain layer remains protocol-aware by necessity. The principle applies above the contract layer, not at it.
+
+## Enforcement
+
+- **Code review:** any PR that introduces a protocol name in FE, agents, gateway, or bot must be rejected with a link to this ADR.
+- **Static check (future):** add a lint rule that fails on the grep set `(uniswap|lido|benqi|aerodrome|moonwell|traderjoe|thirdweb|tac)` outside `backend/*/src/infrastructure/adapters/`. Tracked as a follow-up in `REFACTOR_PLAN.md`.
+- **Architecture review:** quarterly, audit a sample of capability endpoints to verify FE and agents are not branching on `response.provider.name` for business logic. Provider name is observability-only.
+
+## References
+
+- `SPRINT_KICKOFF.md` § 1 (Why this refactor), § 2 (System view: today vs target)
+- `REFACTOR_PLAN.md` Phase 4 (legacy service deletion)
+- ADR 002 (capability-provider abstraction) — the mechanism this principle commits to
+- ADR 004 (layer dependency rules) — the imports this principle forbids
+- Current anti-pattern site: `telegram/apps/miniapp/next.config.ts` rewrite of `/api/lending/benqi/*`
+- Current anti-pattern site: `backend/liquid-swap-service/src/application/services/provider-selector.service.ts:179-196` (hardcoded `BASE_CHAIN_ID`-keyed if/else)

--- a/docs/adr/002-capability-provider-abstraction.md
+++ b/docs/adr/002-capability-provider-abstraction.md
@@ -1,0 +1,186 @@
+# ADR 002 — Capability + Provider abstraction
+
+- **Status:** Accepted
+- **Date:** 2026-05-22
+- **Deciders:** Panorama-Block engineering
+- **Related cards:** Panorama-Block/execution-layer#75
+- **Supersedes:** —
+
+## Context
+
+ADR 001 commits to keeping protocol names inside the backend. This ADR specifies the **mechanism** that makes that possible. Without a concrete pattern, "protocol-agnostic FE" decays back into special cases the first time a protocol behaves differently.
+
+The pattern already exists, partially, in `backend/liquid-swap-service/`: a domain port `ISwapProvider`, multiple adapters (Uniswap, Thirdweb, Aerodrome, Multihop), and an application service `ProviderSelectorService` that picks one based on chain. The same shape should hold for lending, staking, liquidity, bridge, and automation.
+
+This ADR generalizes that shape and locks the vocabulary.
+
+## Decision
+
+The backend organizes every protocol-touching feature into three concentric layers:
+
+1. **Capability** — a verb-shaped business action, identified by a slug from a closed set. Today: `swap`, `lending`, `staking`, `liquidity`, `bridge`, `automation`. New capabilities require an ADR.
+2. **Provider** — a concrete implementation of one capability, identified by a string name (e.g. `uniswap`, `lido`, `benqi`). Multiple providers can serve the same capability. New providers require only a code change, never an ADR.
+3. **Registry + Policy** — `shared/capability/` owns the generic registry that holds providers, plus a policy that ranks them per request (by chain, asset, health).
+
+### Vocabulary (canonical)
+
+| Term | Definition | Lives in |
+|---|---|---|
+| **Capability** | A verb-shaped backend ability (`swap`, `lending`, …) exposed at `/v1/capability/<slug>/...`. | `backend/<service>/src/application/services/<cap>.capability.service.ts` |
+| **Provider** | A class that implements `I<Cap>Provider`; talks to one external protocol. | `backend/<service>/src/infrastructure/adapters/<provider>.adapter.ts` |
+| **Port** | The interface that every provider of a capability must implement. Lives in domain. | `backend/<service>/src/domain/ports/<cap>.provider.port.ts` |
+| **Registry** | Generic container that holds providers and answers `listByChain`, `getByName`. | `backend/shared/capability/registry.ts` |
+| **Policy** | Strategy that orders providers for a given request (priority list per chain). | `backend/shared/capability/policy.ts` |
+| **Adapter** | Same as Provider — the term "adapter" is used when emphasising the hex architecture role; "provider" when emphasising the business role. | `backend/<service>/src/infrastructure/adapters/` |
+| **Envelope** | `CapabilityRequest<T>` / `CapabilityResponse<T>` — the request/response shape every capability speaks. | `backend/shared/capability/envelope.types.ts` |
+| **Facade** | The application-layer service that orchestrates registry + policy + selected provider per request. Same as the capability service. | `backend/<service>/src/application/services/<cap>.capability.service.ts` |
+
+### Five-layer pattern per capability
+
+Each capability follows this exact shape:
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│ Layer 1 — DOMAIN PORT                                          │
+│   <service>/src/domain/ports/<cap>.provider.port.ts            │
+│   interface I<Cap>Provider extends ICapabilityProvider { ... } │
+├────────────────────────────────────────────────────────────────┤
+│ Layer 2 — INFRASTRUCTURE ADAPTER                               │
+│   <service>/src/infrastructure/adapters/<provider>.adapter.ts  │
+│   class <Provider>Adapter implements I<Cap>Provider { ... }    │
+├────────────────────────────────────────────────────────────────┤
+│ Layer 3 — APPLICATION FACADE                                   │
+│   <service>/src/application/services/<cap>.capability.service  │
+│   class <Cap>CapabilityService(registry, policy) { ... }       │
+├────────────────────────────────────────────────────────────────┤
+│ Layer 4 — HTTP CONTROLLER + ROUTES                             │
+│   <service>/src/infrastructure/http/controllers/<cap>.*.ts     │
+│   app.<method>('/v1/capability/<slug>/<action>', controller)   │
+├────────────────────────────────────────────────────────────────┤
+│ Layer 5 — DI / COMPOSITION ROOT                                │
+│   <service>/src/infrastructure/di/container.ts                 │
+│   registry.register(new <Provider>Adapter(...))                │
+└────────────────────────────────────────────────────────────────┘
+```
+
+### Reference snippet (illustrative — actual types defined in cards #200, #204 of the sprint)
+
+```typescript
+// Layer 1 — port
+import { ICapabilityProvider } from "@panorama/shared/capability";
+
+export interface IStakingProvider extends ICapabilityProvider {
+  getPosition(userAddress: string, chainId: number): Promise<StakingPosition>;
+  prepareStake(req: PrepareStakeRequest): Promise<Transaction[]>;
+  // ...
+}
+
+// Layer 2 — adapter
+export class LidoProviderAdapter implements IStakingProvider {
+  readonly name = "lido";
+  readonly metadata = {
+    name: "lido",
+    capability: "staking" as const,
+    supportedChains: [1],
+    features: ["stETH"],
+    version: "1.0.0",
+  };
+  async getPosition(addr, chainId) { /* call Lido SDK */ }
+  async prepareStake(req)          { /* build tx via Lido contract */ }
+}
+
+// Layer 3 — facade
+export class StakingCapabilityService {
+  constructor(
+    private registry: ProviderRegistry<IStakingProvider>,
+    private policy: IPriorityPolicy
+  ) {}
+  async prepareStake(req: CapabilityRequest<PrepareStakeInput>) {
+    const candidates = this.registry.listByChain(req.chainId, "staking");
+    const ranked = this.policy.rank(candidates, req);
+    for (const p of ranked) {
+      if (await p.supportsRoute(req)) return p.prepareStake(req.payload);
+    }
+    throw CapabilityError.unsupportedRoute({ attempted: ranked.map(p => p.name) });
+  }
+}
+
+// Layer 5 — DI
+const registry = new ProviderRegistry<IStakingProvider>();
+registry.register(new LidoProviderAdapter(/* deps */));
+registry.register(new BaseStakingProviderAdapter(/* stub */));
+const policy = new ChainAssetPriorityPolicy(loadJson("config/staking-priority.json"));
+const facade = new StakingCapabilityService(registry, policy);
+```
+
+### Invariants
+
+These hold **without exception**. A PR that violates any one is rejected.
+
+1. **Domain does not import from application or infrastructure.** Ports are pure interfaces.
+2. **Adapters do not import from other services.** Adapters use the port of their own capability + types from `shared/capability/`. No `import { … } from '../../../other-service'`.
+3. **The facade does not know any adapter by name.** It only knows the port and the registry.
+4. **The controller has no business logic.** It only parses input, calls the facade, wraps the response. Anything more belongs in the facade.
+5. **The DI container is the only place that does `new <Concrete>Adapter()`.** This keeps tests free to inject fakes.
+6. **Provider name is observability metadata, not control flow.** Neither FE nor agents may branch on `response.provider.name`. (FE may *display* it; that's fine.)
+7. **The envelope is mandatory at the public surface.** Every `/v1/capability/<slug>/<action>` request and response uses `CapabilityRequest<T>` / `CapabilityResponse<T>` from `shared/capability/`.
+
+### Discovery
+
+A consequence of this pattern is that the system can introspect itself. `GET /v1/capability/_discovery` returns:
+
+```json
+{
+  "capabilities": [
+    {
+      "slug": "swap",
+      "byChain": {
+        "8453": [
+          { "provider": "aerodrome", "healthy": true, "latencyP95Ms": 120 },
+          { "provider": "uniswap-trading-api", "healthy": true, "latencyP95Ms": 240 }
+        ],
+        "1": [...]
+      }
+    }
+  ],
+  "generatedAt": "2026-05-22T14:00:00Z",
+  "cacheTtlSeconds": 30
+}
+```
+
+The FE consumes this to drive feature visibility (cf. SPRINT_MARCOS.md #196). The discovery endpoint is load-bearing under ADR 001 §"Discovery becomes load-bearing": if it goes down, the FE may either over-restrict (safe degradation) or fail open (configurable, default: over-restrict).
+
+## Consequences
+
+### Positive
+
+- One mental model for all six capabilities — reading one capability service is enough to understand the others.
+- New providers ship behind feature flags via `metadata.enabled = false` until ready (`BaseStakingProviderAdapter` stub in card #248 is the example).
+- Conformance tests (card #210) reuse a shared helper, so adapter quality is uniform across the system.
+- Health degradation is graceful: an unhealthy provider drops out of `listByChain` automatically; the facade keeps serving via the next one. No 500s when a single provider hiccups.
+
+### Negative
+
+- Boilerplate per capability: ~5 files for a feature that today might be a single route handler. The win is amortised over the second provider in that capability.
+- The capability slug set is closed by ADR. Opening it (e.g., adding `derivatives`) costs an ADR. This is intentional friction — capabilities are a vocabulary, not a free-form tag.
+- The policy file becomes a runtime config artifact that operations must care about. A bad policy commit can starve a healthy provider. Mitigation: policies live in `config/<cap>-priority.policy.json` next to the service, reviewed on the same PR as adapter changes.
+
+### Neutral
+
+- "Adapter" vs "provider" is a deliberate doublet. The hex-architecture-flavoured PRs call them adapters; the product-flavoured PRs call them providers. Both terms refer to the same class. The glossary above pins this.
+
+## Out of scope (for this ADR)
+
+- Storage strategy per service (each service owns its DB; covered by current `database` gateway conventions in `backend/database/README.md`).
+- Smart-contract layer abstractions (covered separately in ADR 005 for chain onboarding, and in the on-chain `IProtocolAdapter` interface inside the contracts repo).
+- Per-tenant feature gating beyond the discovery healthy/unhealthy bit.
+
+## References
+
+- ADR 001 (backend-first architecture) — the principle this ADR implements
+- ADR 004 (layer dependency rules) — the import graph this pattern requires
+- `SPRINT_KICKOFF.md` § 3–5 (capability pattern, registry deep-dive, anatomy of a request)
+- Sprint cards that implement this ADR:
+  - `panoramablock-backend#199–#203` (envelope, errors, provider metadata, availability — Hugo)
+  - `panoramablock-backend#204–#210` (registry, policy, health, discovery, conformance — Hugo)
+- Current reference implementation (partial): `backend/liquid-swap-service/src/domain/ports/swap.provider.port.ts`, `backend/liquid-swap-service/src/application/services/provider-selector.service.ts`

--- a/docs/adr/003-lane-feature-taxonomy.md
+++ b/docs/adr/003-lane-feature-taxonomy.md
@@ -1,0 +1,102 @@
+# ADR 003 — Lane and Feature taxonomy
+
+- **Status:** Accepted
+- **Date:** 2026-05-22
+- **Deciders:** Panorama-Block engineering
+- **Related cards:** Panorama-Block/execution-layer#76
+
+## Context
+
+The PanoramaBlock Planning board ([project #1](https://github.com/orgs/Panorama-Block/projects/1)) uses two custom fields to organise the 106-card sprint backlog: **Lane** and **Feature**. They look interchangeable but answer different questions:
+
+- **Lane** = the *subsystem* a card lives in. Stable, low-cardinality, dev-owned. Example: `Swap Capability`.
+- **Feature** = the *kind of work* within a lane. Higher-cardinality, evolves per sprint. Example: `Capability API`, `Providers`.
+
+This pairing is what makes the board readable across 4 devs. But the values currently live only as free-form strings on each card — anyone with edit rights can rename them, and a stray rename breaks every saved view and report. This ADR pins the vocabulary.
+
+## Decision
+
+### Lanes are a closed set of 18
+
+Each lane has exactly one owner. Adding or renaming a lane requires a new ADR. The current set:
+
+| Lane | Owner | Scope |
+|---|---|---|
+| Platform Foundation | Hugo | `backend/shared/capability/*` + exec-layer ADRs |
+| Provider Platform | Hugo | Registry, policy, chain onboarding |
+| Staking Capability | Hugo | `backend/lido-service/*` |
+| Identity and Session | Marcos (BE) / Coletto (telegram bridge) | `backend/auth-service/*` + `telegram/.../telegram-auth.ts` |
+| Swap Capability | Rizzi | `backend/liquid-swap-service/*` |
+| Liquidity Capability | Rizzi | `backend/liquidity-service/*` (NEW) |
+| Lending Capability | Marcos | `backend/lending-service/*` |
+| Automation and DCA | Marcos | `backend/dca-service/*` |
+| Bridge Capability | Coletto | `backend/bridge-service/*` |
+| Monitoring and Status | Coletto | `backend/monitoring-service/*` (NEW) |
+| Portfolio and State | Coletto | `backend/portfolio-service/*` (NEW) |
+| Execution Layer Contracts | Hugo | `execution-layer/contracts/*` + deploy scripts |
+| Execution Planning | Marcos | Multi-step plan building (lives inside `dca-service`) |
+| Gateway and BFF Adapter | Coletto | `telegram/apps/gateway/*` |
+| Telegram Adapter | Coletto | Bot commands + deep-link |
+| Web and MiniApp Adapter | Marcos + Rizzi | `telegram/apps/miniapp/src/{shared/lib,features}/*` |
+| Agent Adapter | Rizzi | `zico_agents/new_zico/src/agents/*` |
+| Quality and Delivery | Coletto | Sprint reports, audit, test infrastructure |
+
+### Features evolve per sprint; current set is open
+
+A feature describes the *kind* of work inside a lane. Different lanes can share feature names — both `Swap Capability` and `Lending Capability` have a `Capability API` feature. That's intentional: same template of work across lanes.
+
+Current feature set in this sprint (no per-feature ownership — owner comes from the lane):
+
+| Feature | Appears in lanes | Meaning |
+|---|---|---|
+| Capability API | Swap, Lending, Staking, Liquidity, Bridge | Port, facade, endpoint namespace (~3 cards) |
+| Providers | Swap, Lending, Staking, Liquidity, Bridge | Wrap protocols as providers + conformance tests (~3 cards) |
+| Capability Contracts | Platform Foundation | Envelope, errors, provider metadata, availability schema |
+| Provider Registry | Provider Platform | Registry, policy, health, loader, conformance helper, discovery |
+| Chain Onboarding | Provider Platform | Manifests for Base, Avax, Eth |
+| Auth Capability | Identity and Session | Doc, facade, types, smoke tests |
+| Automation Capability | Automation and DCA | DCA-flavoured capability service |
+| Execution Capability | Execution Planning | Multi-step plan builder, validation |
+| Architecture Guardrails | Platform Foundation (exec-layer) | The 5 ADRs you're reading |
+| Execution Substrate | Execution Layer Contracts | Deploy + register adapters on-chain |
+| Adapter Surface | Gateway and BFF Adapter | Gateway facade, proxy, discovery route |
+| Telegram Integration | Telegram Adapter | Bot commands, deep-links |
+| Web Integration | Web and MiniApp Adapter | `capabilityClient`, discovery, visibility |
+| Intent Translation | Agent Adapter | Agents → capability vocabulary, intent schemas |
+| Monitoring Capability | Monitoring and Status | Health aggregator, status endpoints |
+| Portfolio Capability | Portfolio and State | Cross-capability aggregation |
+| Testing and Visibility | Quality and Delivery | Status report templates, sprint mapping |
+| Chain Onboarding | Provider Platform (exec-layer) | Template for adding a chain to the exec-layer side |
+
+### Rules
+
+1. **Lane is closed.** Adding/removing/renaming a lane requires an ADR amendment to this one. A PR labelled with a non-existent lane on its card is invalid.
+2. **Feature is open but tracked.** A new feature value can be introduced by any dev, but must be added as a comment on the card (`feature: <new-name>`) and added to a tracking issue (`Panorama-Block/panorama-block#FEATURE_REGISTRY`, to be opened by Coletto in the sprint #87/#88 quality work).
+3. **One card belongs to exactly one lane and one feature.** Cross-cutting work is split into multiple cards.
+4. **Lane ownership is inherited by the cards.** When the board moves a card to "In Progress", the assignee is the lane owner unless explicitly overridden (which itself requires a comment justifying the cross-team work).
+5. **Feature ownership = lane ownership.** Features are organisational, not allocative.
+
+## Consequences
+
+### Positive
+
+- Saved views ("My Lane: Swap Capability", "Feature: Providers") become stable across sprints.
+- Status reports group naturally: "this sprint shipped X cards in Capability API across 5 lanes".
+- A new dev joining the team can read the lane table and immediately know whom to ping.
+- Renames stop being a vector for silent breakage of dashboards.
+
+### Negative
+
+- Some real work is cross-lane (e.g., `auth` touches both `Identity and Session` backend and `Identity and Session` telegram). The rule "one card = one lane" forces this into two cards. That's the cost of clarity.
+- Lane closure adds friction when product asks for a brand-new domain (e.g., `Insurance Capability`). The friction is intentional: the cost is one ADR, which forces alignment.
+
+### Neutral
+
+- The taxonomy is observable but not enforced by tooling today. Enforcement (e.g., GitHub Action that rejects card edits with unknown lane) is a future improvement; for now, code review enforces it informally during card grooming.
+
+## References
+
+- ADR 002 (capability-provider abstraction) — defines the capability slugs that map 1-to-1 to most lanes
+- `SPRINT_KICKOFF.md` § 8 (Divisão por dev) — the same lane→owner mapping operationalised
+- [PanoramaBlock Planning board](https://github.com/orgs/Panorama-Block/projects/1)
+- Sprint card #87 (feature status report template — Coletto) — will produce the per-sprint snapshot of this taxonomy

--- a/docs/adr/004-layer-dependency-rules.md
+++ b/docs/adr/004-layer-dependency-rules.md
@@ -1,0 +1,164 @@
+# ADR 004 — Layer dependency rules
+
+- **Status:** Accepted
+- **Date:** 2026-05-22
+- **Deciders:** Panorama-Block engineering
+- **Related cards:** Panorama-Block/execution-layer#77
+
+## Context
+
+ADR 002 introduces the Capability + Provider pattern with five layers per capability and a shared foundation in `backend/shared/capability/`. The pattern only delivers its promise (uniform shape, easy provider swap, isolated services) if the **import graph** stays one-directional.
+
+We have lived with import inversions before: services calling each other directly (`liquid-swap-service` historically called helpers in `lending-service`), application code reaching into infrastructure of a sibling, and adapters of one service leaking types from another. Each instance survived because it was small. The aggregate cost is the current sprint: untangling those crossings is now half the work of the refactor.
+
+This ADR fixes the rules so the cost doesn't recur.
+
+## Decision
+
+The system has three layers, and edges go only one direction.
+
+```mermaid
+flowchart TD
+    subgraph L0 [" Layer 0 — Foundation (shared/capability) "]
+        F["backend/shared/capability/*<br/>envelope, errors, registry, policy,<br/>health, chains, conventions"]
+    end
+
+    subgraph L1A [" Layer 1A — Capability backend services "]
+        SWAP["liquid-swap-service"]
+        STAKE["lido-service (staking)"]
+        LEND["lending-service"]
+        LIQ["liquidity-service"]
+        BRIDGE["bridge-service"]
+        DCA["dca-service"]
+        AUTH["auth-service"]
+    end
+
+    subgraph L1B [" Layer 1B — Cross-cutting backend services "]
+        MON["monitoring-service"]
+        PORT["portfolio-service"]
+        DB["database (gateway)"]
+    end
+
+    subgraph L2 [" Layer 2 — Adapters (FE / agents / bot / gateway) "]
+        GW["telegram/apps/gateway"]
+        APP["telegram/apps/miniapp"]
+        BOT["telegram bot commands"]
+        AGENTS["zico_agents"]
+    end
+
+    L1A -->|imports types| F
+    L1B -->|imports types| F
+    L1B -->|HTTP calls| L1A
+    L2 -->|HTTP via gateway| L1A
+    L2 -->|HTTP via gateway| L1B
+    GW -->|HTTP proxy| L1A
+    GW -->|HTTP proxy| L1B
+```
+
+### The hard rules
+
+Every PR is checked against these. Violation = block.
+
+1. **`backend/shared/capability/` is a sink.** It imports from nothing else inside the monorepo. External libs (zod, etc.) are fine; nothing under `backend/<service>/*` or `execution-layer/*` is allowed.
+2. **No backend service imports from another backend service.** `lending-service` cannot `import { ... } from '../../liquid-swap-service/...'`. Cross-service communication is HTTP-only, through the gateway when called from outside the backend, or direct HTTP between services when both are in the cluster (cross-cutting services like `monitoring`, `portfolio` do this).
+3. **Adapters import only from their own service's domain + `shared/capability/`.** `LidoProviderAdapter` (in `lido-service/infrastructure/adapters/`) imports `IStakingProvider` from `lido-service/domain/ports/` and `Transaction` from `shared/capability/`. It does *not* import from `liquid-swap-service` or `dca-service`.
+4. **Domain does not import from application or infrastructure.** Ports are pure types. They can depend on `shared/capability/` types and external lib types only.
+5. **The composition root (`<service>/infrastructure/di/container.ts`) is the only place that does `new <Adapter>(...)`.** Tests instantiate fakes; everywhere else receives instances by injection.
+6. **No FE/agent/bot/gateway file may import from `backend/<service>/*` source.** They talk HTTP. Type-sharing happens by publishing types into a shared package (future: `@panorama/capability-types`); for this sprint, types are duplicated minimally in FE and that's acceptable.
+7. **Smart contracts (`execution-layer/contracts/`) are not imported by TypeScript code.** Backend talks to deployed contract addresses via ethers + ABIs (which live in `execution-layer/backend/src/`). On-chain code is its own dependency island.
+
+### Where to put new code (decision tree)
+
+```
+Is it a TYPE/INTERFACE used across multiple services?
+  YES → backend/shared/capability/
+  NO  → goes inside one service
+
+Is it talking to an external protocol (Uniswap, Lido, Benqi, …)?
+  YES → backend/<service>/src/infrastructure/adapters/<provider>.adapter.ts
+  NO  → continue
+
+Is it orchestration across multiple providers of one capability?
+  YES → backend/<service>/src/application/services/<cap>.capability.service.ts
+  NO  → continue
+
+Is it an HTTP endpoint?
+  YES → backend/<service>/src/infrastructure/http/{controllers,routes}/
+  NO  → continue
+
+Is it a pure domain rule (validation, entity invariant)?
+  YES → backend/<service>/src/domain/
+  NO  → reconsider — it probably doesn't belong in this service.
+```
+
+### Examples of accepted and rejected imports
+
+✅ **Accepted:**
+```typescript
+// in lido-service/src/infrastructure/adapters/lido.provider.adapter.ts
+import { IStakingProvider } from "../../domain/ports/staking.provider.port";
+import { Transaction, CapabilityError } from "@panorama/shared/capability";
+import { ethers } from "ethers";
+```
+
+✅ **Accepted (cross-cutting service calling capability over HTTP):**
+```typescript
+// in portfolio-service/src/infrastructure/adapters/cross-capability-aggregator.adapter.ts
+const stakingPositions = await fetch(`${STAKING_SVC_URL}/v1/capability/staking/position/${addr}`);
+```
+
+❌ **Rejected (cross-service import):**
+```typescript
+// in lending-service/src/application/services/lending.service.ts
+import { LidoService } from "../../../../lido-service/src/application/services/LidoService"; // BAN
+```
+
+❌ **Rejected (domain depending on infrastructure):**
+```typescript
+// in liquid-swap-service/src/domain/services/router.domain.service.ts
+import { UniswapAdapter } from "../../infrastructure/adapters/uniswap.swap.adapter"; // BAN
+```
+
+❌ **Rejected (FE reaching into backend source):**
+```typescript
+// in telegram/apps/miniapp/src/features/swap/api.ts
+import type { SwapQuote } from "../../../../../backend/liquid-swap-service/src/domain/entities/swap"; // BAN
+```
+
+❌ **Rejected (shared/capability reaching into a service):**
+```typescript
+// in backend/shared/capability/registry.ts
+import { LidoService } from "../../lido-service/src/application/services/LidoService"; // BAN — capability foundation cannot know any service
+```
+
+## Consequences
+
+### Positive
+
+- Each service can be built, tested, deployed independently. No accidental coupling.
+- Replacing a service implementation (rewrite, language change) doesn't ripple. The contract is the HTTP surface.
+- Test setup is trivial: instantiate the adapter under test with mock deps; nothing pulls in 5 other services.
+- The Camada 0 work in `shared/capability/` can be developed once and consumed everywhere with no risk of circular imports.
+
+### Negative
+
+- Some "obvious" reuses become HTTP calls. Example: lending wants to know the user's swap history to suggest a collateral; under these rules it must call `portfolio-service` over HTTP, not import from `liquid-swap-service`. The overhead is real but small (intra-cluster latency, low ms) and pays the architecture dividend.
+- Type duplication between BE and FE until a `@panorama/capability-types` package exists. The duplication is shallow (request/response shapes, ~50 LOC) and the FE keeps its own validation layer.
+
+### Neutral
+
+- The rules are enforceable today by code review and grep; a future ESLint plugin (`eslint-plugin-boundaries` or `dependency-cruiser` config) is on the backlog. Until then, the reviewer pair (see `SPRINT_KICKOFF.md` § 11) is responsible.
+
+## Enforcement
+
+- **Code review check (now):** the reviewer runs `grep -r "from '\.\./\.\./.*\(liquid-swap\|lending\|lido\|dca\|bridge\|auth\)-service'" backend/<service>/src/` on changed files. Any hit → rejection with a link to this ADR.
+- **CI lint (future):** add `dependency-cruiser` config in repo root that codifies the layer matrix above and fails CI on violations. Tracked as a follow-up issue in the next sprint.
+- **Audit (quarterly):** run the same grep across the full monorepo. New violations → file a card to extract the offending logic into `shared/capability/` (if generic) or to add a proper HTTP edge (if not).
+
+## References
+
+- ADR 001 (backend-first architecture)
+- ADR 002 (capability-provider abstraction) — the layered pattern this ADR pins
+- ADR 003 (lane and feature taxonomy) — owners that enforce these rules
+- `SPRINT_KICKOFF.md` § 3 (capability pattern in 5 layers), § 11 (review pairs)
+- Existing reference impl that respects these rules: `backend/liquid-swap-service/src/domain/ports/swap.provider.port.ts` (port has no infra imports)

--- a/docs/adr/005-chain-onboarding-model.md
+++ b/docs/adr/005-chain-onboarding-model.md
@@ -1,0 +1,110 @@
+# ADR 005 — Chain onboarding model
+
+- **Status:** Accepted
+- **Date:** 2026-05-22
+- **Deciders:** Panorama-Block engineering
+- **Related cards:** Panorama-Block/execution-layer#78
+
+## Context
+
+Today, chain identity is scattered through the codebase. The most visible offender is `backend/liquid-swap-service/src/application/services/provider-selector.service.ts:8`:
+
+```typescript
+const BASE_CHAIN_ID = 8453;
+// ...
+if (isSameChain && isBase) {
+  providerPriority = ["aerodrome", "uniswap-trading-api", "uniswap", "thirdweb"];
+}
+```
+
+The same magic number `8453` appears in execution-layer scripts, in mini-app feature configs, and in `zico_agents` prompts. Avalanche (`43114`) and Ethereum (`1`) repeat the pattern. The result is that adding a chain (or even verifying that Base is consistently configured across services) requires a global grep + 6 file edits + 4 deploys.
+
+We also have no formal definition of "what does this chain support?". The fact that swap providers exist for Base is implicit — encoded in the if/else above and in adapter registrations. There is no machine-readable answer to "does PanoramaBlock support lending in Avalanche?".
+
+ADR 002 introduces the Capability + Provider pattern but stays silent on chains. This ADR fills the gap: chains become a first-class entity with a manifest, owned by `backend/shared/capability/chains/`, and consumed everywhere chain identity matters.
+
+## Decision
+
+Each supported chain is described by a **manifest file** in `backend/shared/capability/chains/<slug>.manifest.json`. The shape is fixed; consumers read through a typed loader. No service hardcodes chain ID anywhere — they all go through `getChain(idOrSlug)`.
+
+### Manifest shape
+
+```typescript
+interface ChainManifest {
+  id: number;                      // 8453, 43114, 1
+  slug: string;                    // 'base', 'avalanche', 'ethereum' (kebab-case)
+  name: string;                    // 'Base', 'Avalanche', 'Ethereum'
+  nativeAsset: {
+    symbol: string;                // 'ETH', 'AVAX', 'ETH'
+    decimals: number;              // 18
+  };
+  rpcDefaults: string[];           // public RPC URLs; never include keys
+  blockExplorerUrl: string;        // 'https://basescan.org'
+  capabilitiesSupported: CapabilitySlug[];  // ['swap', 'lending', 'liquidity']
+}
+```
+
+### Concrete manifests for this sprint
+
+Created in cards #211–#214 (Hugo). Slugs and capability sets are pinned here:
+
+| Slug | id | Native | Supported capabilities |
+|---|---|---|---|
+| `base` | 8453 | ETH | swap, lending, liquidity |
+| `avalanche` | 43114 | AVAX | swap, lending, liquidity, staking |
+| `ethereum` | 1 | ETH | swap, staking |
+
+Note `staking` is not in Base yet (Lido is Ethereum-only; cbETH stub via card #248 will add it later); `bridge` and `automation` are cross-chain and not declared per chain — they declare their own supported `from→to` matrix in the provider metadata.
+
+### How a chain is added (the playbook)
+
+1. **Open an ADR amendment** to this one, or a follow-up ADR for the new chain. Justify why this chain belongs in PanoramaBlock (TAM, user demand, capabilities expected).
+2. **Create the manifest** `backend/shared/capability/chains/<slug>.manifest.json`. List `capabilitiesSupported` honestly — declare a capability only if at least one provider for that chain will exist by sprint end.
+3. **For each capability supported on this chain**, ensure a provider adapter exists or open a card to add one. The adapter's `metadata.supportedChains` must include the new chain id, otherwise `registry.listByChain(newChainId)` returns empty.
+4. **Update on-chain artifacts** if the capability needs them: deploy `PanoramaExecutorV2` and required adapters to the new chain (see `execution-layer/docs/templates/onboard-chain.md` from card #79). Record addresses in `execution-layer/deployments/<slug>/`.
+5. **Add to the policy config** of each affected capability service: `backend/<service>/config/<cap>-priority.policy.json` gains a `"<newChainId>": [provider names ordered]` entry.
+6. **Smoke-test** discovery: `GET /v1/capability/_discovery` should now return the new chain id with its providers and health.
+7. **Communicate** in `#panorama-dev`: "🆕 Chain `<slug>` (id `<X>`) live with capabilities `[...]`. FE feature visibility will pick it up on next discovery refresh."
+
+### Rules
+
+1. **No `<chainId> as literal number` outside manifests.** Search `grep -r '\b(8453|43114|1|10|137|42161)\b'` periodically; hits in service code are violations and must be replaced with `getChain('base').id`.
+2. **Slug, not number.** Inter-service references use slugs (`'base'`, `'avalanche'`). Numbers are used only when an external SDK (ethers, viem) requires them; convert at the call site.
+3. **Capability claims must be honest.** Listing `staking` for Base while no Base staking provider exists is a bug. The `BaseStakingProviderAdapter` stub in card #248 is registered with `metadata.enabled = false` precisely to avoid this — stubs don't count.
+4. **RPC defaults are public only.** `rpcDefaults` contains URLs anyone can use (e.g., `https://base.publicnode.com`). Per-tenant or paid RPCs come from env vars at runtime, not from the manifest.
+5. **Native asset is canonical.** When a capability needs to refer to "the chain's native asset", it goes through the manifest, not a per-service constant.
+
+## Consequences
+
+### Positive
+
+- Adding a chain becomes a 1-PR change (new manifest + adapter `supportedChains` updates) instead of a hunt across 6 files.
+- "Does PanoramaBlock support X on chain Y?" has a single answer: `getChain(Y).capabilitiesSupported.includes(X)`.
+- The FE discovery endpoint can enumerate chains from `loadChains()` rather than from a hardcoded set.
+- Cross-chain features (bridge, future cross-chain swaps) can iterate manifests instead of maintaining a separate chain registry.
+
+### Negative
+
+- The first migration cost: every existing site with `8453` / `43114` / `1` literal must be replaced. Tracked in the audit notes of card #212 (Base manifest) — Rizzi will get a follow-up issue listing the call sites in `liquid-swap-service`.
+- The manifest is now a runtime artifact. A bad commit (e.g., wrong RPC URL) can affect all services that read it. Mitigation: manifests live with shared/capability and PRs that touch them require Hugo's approval.
+- Some services don't care about chains (auth-service is chain-agnostic for now). They simply don't import `getChain`. That's fine.
+
+### Neutral
+
+- The on-chain side has its own per-chain registry (`execution-layer/deployments/<slug>/`). The backend manifest and the on-chain registry are two different artifacts with overlapping purpose. Keeping them in sync is procedural — handled by the onboarding playbook above — not enforced by tooling in this sprint.
+
+## Out of scope (for this ADR)
+
+- Per-chain feature flags beyond the `capabilitiesSupported` array. If we need finer control ("Avalanche supports lending but only for AVAX collateral"), that's a per-provider concern (`provider.metadata.features`), not a chain concern.
+- Testnet manifests. This sprint targets mainnets; testnet manifests can be added without amending this ADR as long as they follow the same shape.
+- Chain reorg handling and reorg-safe transactions. Provider responsibility, not chain manifest.
+
+## References
+
+- ADR 001 (backend-first architecture)
+- ADR 002 (capability-provider abstraction) — defines `CapabilitySlug` used in `capabilitiesSupported`
+- ADR 004 (layer dependency rules) — chains module lives in `shared/capability/chains/`, a layer-0 module
+- `SPRINT_HUGO.md` cards #211–#214 (manifest types + the 3 chain files)
+- `SPRINT_HUGO.md` cards #81–#86 (smart-contract deploy on Base mainnet, the first on-chain side of the chain registry)
+- `SPRINT_COLETTO.md` card #79 (`execution-layer/docs/templates/onboard-chain.md`) — the playbook step 4 documented end-to-end
+- Existing anti-pattern site: `backend/liquid-swap-service/src/application/services/provider-selector.service.ts:8` (`const BASE_CHAIN_ID = 8453`)


### PR DESCRIPTION
## Cards

- Closes Panorama-Block/execution-layer#74 — Document backend-first architecture principle
- Closes Panorama-Block/execution-layer#75 — Document capability-provider abstraction
- Closes Panorama-Block/execution-layer#76 — Define lane and feature taxonomy
- Closes Panorama-Block/execution-layer#77 — Publish dependency rules by layer
- Closes Panorama-Block/execution-layer#78 — Create ADR for chain onboarding model

## Mudanças

Adiciona 5 ADRs (Architecture Decision Records) que ancoram a refatoração capability-first deste sprint:

- `docs/adr/001-backend-first-architecture.md` — princípio: protocol names só dentro de backend adapters
- `docs/adr/002-capability-provider-abstraction.md` — padrão de 5 camadas (port/adapter/facade/controller/DI) + vocabulário canônico
- `docs/adr/003-lane-feature-taxonomy.md` — taxonomia fechada de 18 Lanes do board
- `docs/adr/004-layer-dependency-rules.md` — `shared/capability/` é sink; sem imports cross-service; FE/agents só HTTP
- `docs/adr/005-chain-onboarding-model.md` — chains via manifest; sem chainId literal fora de `shared/capability/chains/`

`CLAUDE.md` atualizado para linkar os ADRs como leitura obrigatória antes de mudanças arquiteturais.

## Por que agora

Bloco 1 da trilha do Hugo (sprint kickoff 2026-05-22). ADRs vêm primeiro porque os outros devs (Rizzi, Marcos, Coletto) vão referenciá-los ao decompor seus próprios cards.

## Camada / DoD

- [x] Sem código de runtime (só docs `.md`)
- [x] Lint não aplicável a markdown
- [x] Sem mudanças em diretórios fora do meu escopo (apenas `docs/adr/` e `CLAUDE.md`)
- [x] Backward-compat preservada (sem alterações de API)
- [x] Doc atualizado (`CLAUDE.md` lista os 5 ADRs)
- [ ] Review approved por par (Coletto primário, Rizzi secundário)

## Notas para review

- ADR 003 referencia uma issue de tracking `FEATURE_REGISTRY` que Coletto deve criar no sprint (cards #87/#88 — Quality and Delivery). Não é blocker pra esse PR.
- ADR 004 menciona ESLint plugin (`dependency-cruiser`) como follow-up — não está neste PR.
- Cards #211–#214 (manifests Base/Avax/Eth) implementam ADR 005 — virão em PR separado.